### PR TITLE
[WIP] Switch to mdast, use inline styles everywhere

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -68,6 +68,6 @@ And some more text.
 
 ```
 
-## Specimens
+## Specimens
 
 Catalog provides a wide variety of specimens. See the [Specimen documentation](#/specimens) for more

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "isomorphic-fetch": "^2.2.0",
     "js-yaml": "^3.4.3",
-    "marked": "^0.3.2",
+    "mdast": "^2.3.0",
+    "mdast-react": "^0.3.0",
     "prismjs": "^1.3.0",
     "radium": "^0.14.1",
     "ramda": "^0.18.0"

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -31,13 +31,13 @@ class Card extends Component {
         <RadiumStyle
           scopeSelector='.cg-Card >'
           rules={{
-            h2: {
-              ...cardContainer(theme),
-              ...heading(theme, {level: 1}),
-              marginBottom: 20,
-              maxWidth: 'none',
-              flexBasis: '100%'
-            },
+            // h2: {
+            //   ...cardContainer(theme),
+            //   ...heading(theme, {level: 1}),
+            //   marginBottom: 20,
+            //   maxWidth: 'none',
+            //   flexBasis: '100%'
+            // },
             h3: {
               ...cardContainer(theme),
               ...heading(theme, {level: 3}),

--- a/src/components/Page/Page.js
+++ b/src/components/Page/Page.js
@@ -1,0 +1,30 @@
+import React, {Component, PropTypes} from 'react';
+
+export default class Page extends Component {
+  render() {
+    const {children} = this.props;
+    const {theme} = this.context;
+
+    const margin = window.innerWidth > 640 ? theme.sizeL * 2 : theme.sizeL;
+
+    const style = {
+      display: 'flex',
+      flexFlow: 'row wrap',
+      margin: `28px ${margin - 10}px 14px ${margin}px`,
+    }
+
+    return (
+      <div style={style}>
+        {children}
+      </div>
+    );
+  }
+}
+
+Page.propTypes = {
+  children: PropTypes.node
+};
+
+Page.contextTypes = {
+  theme: PropTypes.object.isRequired
+}

--- a/src/components/Page/PageRenderer.js
+++ b/src/components/Page/PageRenderer.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import CatalogPropTypes from '../../CatalogPropTypes';
 
-import MarkdownRenderer from '../../utils/MarkdownRenderer';
+import {renderPageMarkdown} from '../../utils/MarkdownRenderer';
 import { Style as RadiumStyle } from 'radium';
 
 import Card from '../Card/Card';
@@ -13,8 +13,6 @@ import { inlineUlist, inlineOlist } from '../../scaffold/lists';
 function pageContainer(theme) {
   return {
     maxWidth: 671,
-    paddingLeft: theme.sizeL,
-    paddingRight: theme.sizeL
   };
 }
 
@@ -30,63 +28,68 @@ class PageRenderer extends React.Component {
       ...inlineBlockquoteRules.blockquote
     };
 
-    let margin = window.innerWidth > 640 ? theme.sizeL : 0;
+    let margin = window.innerWidth > 640 ? theme.sizeL * 2 : theme.sizeL;
 
     return (
-      <div className='cg-Page' style={{margin: `0 ${margin}px`, flex: 1}}>
-        <RadiumStyle scopeSelector='.cg-Page >' rules={{
-          h2: {
-            ...pageContainer(theme),
-            ...heading(theme, {level: 1})
-          },
-          h3: {
-            ...pageContainer(theme),
-            ...heading(theme, {level: 4}),
-            marginTop: 50
-          },
-          p: {
-            ...pageContainer(theme),
-            ...text(theme, {level: 2})
-          },
-          section: {
-            ...pageContainer(theme)
-          },
-          ...inlineElements(theme, {selector: 'p'}),
-          ...inlineUlist(theme, {
-            selector: 'ul',
-            style: {
-              ...pageContainer(theme),
-              ...text(theme, {level: 2}),
-              marginLeft: '2.4em',
-              boxSizing: 'border-box',
-              width: 'calc(100% - 2.4em)'
-            }
-          }),
-          ...inlineOlist(theme, {
-            selector: 'ol',
-            style: {
-              ...pageContainer(theme),
-              ...text(theme, {level: 2}),
-              marginLeft: '2.4em'
-            }
-          }),
-          ...inlineBlockquoteRules,
-          'h1 + blockquote ~ blockquote p': {
-            fontStyle: 'italic'
-          },
-          hr: {
-            border: 'none',
-            borderBottom: `1px solid ${theme.brandColor}`,
-            margin: '16px 21px',
-            maxWidth: '671px',
-            height: 0
-          }
+      <div className='cg-Page' style={{margin: 0, flex: 1}}>
+        <RadiumStyle scopeSelector='.cg-Page > div >' rules={{
+          // h2: {
+          //   ...pageContainer(theme),
+          //   ...heading(theme, {level: 1})
+          // },
+          // h3: {
+          //   ...pageContainer(theme),
+          //   ...heading(theme, {level: 4}),
+          //   marginTop: 50
+          // },
+          // h4: {
+          //   ...pageContainer(theme),
+          //   ...heading(theme, {level: 5}),
+          //   marginTop: 50
+          // },
+          // p: {
+          //   ...pageContainer(theme),
+          //   ...text(theme, {level: 2})
+          // },
+          // section: {
+          //   ...pageContainer(theme)
+          // },
+          // ...inlineElements(theme, {selector: 'p'}),
+          // ...inlineUlist(theme, {
+          //   selector: 'ul',
+          //   style: {
+          //     ...pageContainer(theme),
+          //     ...text(theme, {level: 2}),
+          //     marginLeft: '2.4em',
+          //     boxSizing: 'border-box',
+          //     width: 'calc(100% - 2.4em)'
+          //   }
+          // }),
+          // ...inlineOlist(theme, {
+          //   selector: 'ol',
+          //   style: {
+          //     ...pageContainer(theme),
+          //     ...text(theme, {level: 2}),
+          //     marginLeft: '2.4em'
+          //   }
+          // }),
+          // ...inlineBlockquoteRules,
+          // 'h1 + blockquote ~ blockquote p': {
+          //   fontStyle: 'italic'
+          // },
+          // hr: {
+          //   border: 'none',
+          //   borderBottom: `1px solid ${theme.brandColor}`,
+          //   margin: '16px 21px',
+          //   maxWidth: '671px',
+          //   height: 0
+          // }
         }} />
         {this.styleNodes()}
 
         <div style={{
           boxSizing: 'border-box',
-          margin: `0 -${margin}px ${margin}px -${margin}px`,
+          margin: `0 0 ${margin}px 0`,
           position: 'relative',
           height: theme.pageHeadingHeight,
           background: theme.pageHeadingBackground
@@ -125,21 +128,19 @@ class PageRenderer extends React.Component {
   }
 
   contentNodes() {
-    if (React.isValidElement(this.props.content)) {
-      return this.props.content;
+    const {content} = this.props;
+    const {theme} = this.context;
+    if (React.isValidElement(content)) {
+      return content;
     }
-    return MarkdownRenderer({
-      text: this.props.content,
-      section: (children) => {
-        return <Card key={seqKey()} theme={this.context.theme}>{children}</Card>;
-      },
-      renderer: {
-        code: (body, options) => {
-          return <MarkdownSpecimen key={seqKey()} body={body} options={options} />;
-        },
-        heading: (headingText, level) => {
-          return React.createElement(`h${level}`, {key: seqKey()}, headingText);
-        }
+    return renderPageMarkdown(content, {
+      styles: {
+        h1: heading(theme, {level: 1}),
+        h2: heading(theme, {level: 2}),
+        h3: heading(theme, {level: 3}),
+        h4: heading(theme, {level: 4}),
+        p: text(theme, {level: 2}),
+        ...inlineElements(theme, {selector: ''})
       }
     });
   }

--- a/src/components/Page/PageRenderer.js
+++ b/src/components/Page/PageRenderer.js
@@ -7,7 +7,7 @@ import { Style as RadiumStyle } from 'radium';
 import Card from '../Card/Card';
 import MarkdownSpecimen from '../Specimen/MarkdownSpecimen';
 
-import { heading, text, inlineElements, inlineBlockquote } from '../../scaffold/typography';
+import { heading, text, inlineElements, inlineBlockquote, code } from '../../scaffold/typography';
 import { inlineUlist, inlineOlist } from '../../scaffold/lists';
 
 function pageContainer(theme) {
@@ -140,6 +140,21 @@ class PageRenderer extends React.Component {
         h3: heading(theme, {level: 3}),
         h4: heading(theme, {level: 4}),
         p: text(theme, {level: 2}),
+        li: text(theme, {level: 2}),
+        code: code(theme),
+        blockquote: {
+          quotes: 'none',
+          margin: '50px 0',
+          paddingLeft: 20,
+          borderLeft: `2px solid ${theme.sidebarColorLine}`
+        },
+        hr: {
+          border: 'none',
+          margin: '0',
+          height: 0,
+          maxWidth: 'none',
+          flexBasis: '100%'
+        },
         ...inlineElements(theme, {selector: ''})
       }
     });

--- a/src/scaffold/typography.js
+++ b/src/scaffold/typography.js
@@ -74,7 +74,7 @@ export function inlineElements(theme, {selector = ''}) {
     [`${selector} b, strong`]: {
       fontWeight: 600
     },
-    [`${selector} a`]: linkStyle,
+    a: linkStyle,
     [`${selector} a:hover`]: linkHoverStyle,
     [`${selector} code`]: code(theme),
     [`${selector} img`]: {
@@ -115,7 +115,8 @@ export function heading(theme, {level}) {
   return {
     ...style,
     ...setType(theme, {fontSize: fontSizes[level], verticalUnits: theme.baseLineMulti}),
-    margin: `0 0 ${fontSizes[level]}px`
+    margin: `0 0 ${fontSizes[level]}px`,
+    flexBasis: '100%'
   };
 }
 

--- a/src/specimens/Hint.js
+++ b/src/specimens/Hint.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import { Style as RadiumStyle } from 'radium';
-import MarkdownRenderer from '../utils/MarkdownRenderer';
+import {renderContentMarkdown} from '../utils/MarkdownRenderer';
 import Specimen from '../components/Specimen/Specimen';
 import {text} from '../scaffold/typography';
 
@@ -58,7 +58,7 @@ class Hint extends React.Component {
               whiteSpace: 'pre-wrap'
             }
           }}/>
-          <div>{MarkdownRenderer({text: text})}</div>
+          <div>{renderContentMarkdown(text)}</div>
         </section>
       );
   }

--- a/src/specimens/Image.js
+++ b/src/specimens/Image.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import Radium, {Style} from 'radium';
 import Specimen from '../components/Specimen/Specimen';
-import MarkdownRenderer from '../utils/MarkdownRenderer';
+import {renderContentMarkdown} from '../utils/MarkdownRenderer';
 
 import {text, link, heading} from '../scaffold/typography';
 
@@ -86,7 +86,7 @@ class Image extends React.Component {
           <img style={styles.image} srcSet={src}/>
           {overlay && <img style={[styles.overlay, options.plain ? {top: 0, left: 0, maxWidth: '100%'} : null ]} srcSet={overlay} />}
           {title && <div style={styles.title}>{title}</div>}
-          {description && <div style={{...styles.description, ...(options.dark ? {color: '#fff'} : null)}}>{MarkdownRenderer({text: description})}</div>}
+          {description && <div style={{...styles.description, ...(options.dark ? {color: '#fff'} : null)}}>{renderContentMarkdown(description)}</div>}
         </div>
     );
   }


### PR DESCRIPTION
An experiment to see if we can tweak the Markdown renderer to apply inline styles. I thought this could solve #71 #73 and #75, and clean up the styling code but I hit some complexities in how much we can customize without basically forking [mdast-react](https://github.com/mapbox/mdast-react).

The main problem is nested elements. Without transforming the AST, nodes are not aware of their parent. And if we want to use inline styles all the way down, for example paragraphs need to know if they're nested inside a blockquote or listItem. And even if we modify the children to be aware of their nesting, I couldn't figure out a straight-forward way to play nice with mdast-react which allows customization of the components used for rendering but only after the AST information is lost.

Turns out, recreating a CSS rule like `blockquote > p` with inline styles is surprisingly difficult :sweat_smile: 

:warning: :skull: **DO NOT MERGE** :skull: :warning: