### PR TITLE
Fix specimen body parsing

### DIFF
--- a/docs/specimens/overview.md
+++ b/docs/specimens/overview.md
@@ -6,7 +6,7 @@
 
 Specimens are defined as Markdown code blocks with an option string.
 
-````code
+````
 ```html|dark
 Content goes here...
 ```
@@ -31,7 +31,7 @@ The first part – the one before the `|`-character – is the specimen __type_
 
 For example:
 
-````code
+````
 ```image
 ...
 ```
@@ -43,7 +43,7 @@ The second part after the `|` is a list of comma-separated __options__ for the s
 
 For example:
 
-````code
+````
 ```code|lang-jsx,span-3
 ...
 ```
@@ -63,7 +63,7 @@ The [HTML](#/html), [Code](#/code), and [Hint](#/hint) specimens take a simple s
 
 For example:
 
-````code
+````
 ```html
 <p>Some HTML</p>
 ```
@@ -75,7 +75,7 @@ Other specimens (like [Color](#/color)) take structured content as input which i
 
 For example:
 
-````code
+````
 ```color
 name: Red
 value: #f00
@@ -88,7 +88,7 @@ To specify __props__ and __content__ together, separate them with `---` followed
 
 For example:
 
-````code
+````
 ```code
 span: 2
 ---

--- a/src/components/Specimen/Specimen.js
+++ b/src/components/Specimen/Specimen.js
@@ -16,18 +16,6 @@ export default function Specimen(mapBodyToProps: Function, mapOptionsToProps: Fu
       const bodyProps = parseBody(rawBody);
       const span = props.span || bodyProps.span || optionProps.span;
 
-      if (Array.isArray(bodyProps)) {
-        return (
-          <Span span={span}>
-            {bodyProps.map((specimenProps, i) => (
-              <Span key={i} span={specimenProps.span}>
-                <WrappedSpecimen {...optionProps} {...specimenProps} {...props}  theme={theme} />
-              </Span>
-            ))}
-          </Span>
-        );
-      }
-
       return (
         <Span span={span}>
           <WrappedSpecimen {...optionProps} {...bodyProps} {...props} theme={theme} />

--- a/src/components/Specimen/Specimen.js
+++ b/src/components/Specimen/Specimen.js
@@ -3,11 +3,11 @@
 import React, {PropTypes} from 'react';
 import Span from './Span';
 import parseSpecimenOptions from '../../utils/parseSpecimenOptions';
-import parseSpecimenBody from '../../utils/parseSpecimenBody';
+import {parseSpecimenBody, parseSpecimenYamlBody} from '../../utils/parseSpecimenBody';
 
-export default function Specimen(mapBodyToProps: Function, mapOptionsToProps: Function) {
+export default function Specimen(mapBodyToProps: Function, mapOptionsToProps: Function, options = {}) {
   const parseOptions = parseSpecimenOptions(mapOptionsToProps);
-  const parseBody = parseSpecimenBody(mapBodyToProps);
+  const parseBody = options.withChildren ? parseSpecimenBody(mapBodyToProps) : parseSpecimenYamlBody(mapBodyToProps);
 
   return (WrappedSpecimen) => {
     const SpecimenContainer = (props, {theme}) => {

--- a/src/specimens/Code.js
+++ b/src/specimens/Code.js
@@ -78,4 +78,4 @@ const mapOptionsToProps = mapSpecimenOption(/^lang-(\w+)$/, (lang) => ({lang}));
 
 const mapBodyToProps = (parsed, rawBody) => ({...parsed, rawBody});
 
-export default Specimen(mapBodyToProps, mapOptionsToProps)(Radium(Code));
+export default Specimen(mapBodyToProps, mapOptionsToProps, {withChildren: true})(Radium(Code));

--- a/src/specimens/Hint.js
+++ b/src/specimens/Hint.js
@@ -80,4 +80,4 @@ Hint.propTypes = {
   directive: PropTypes.bool
 };
 
-export default Specimen()(Hint);
+export default Specimen(undefined, undefined, {withChildren: true})(Hint);

--- a/src/specimens/Html.js
+++ b/src/specimens/Html.js
@@ -137,4 +137,4 @@ Html.propTypes = {
 };
 
 
-export default Specimen()(Radium(Html));
+export default Specimen(undefined, undefined, {withChildren: true})(Radium(Html));

--- a/src/specimens/ReactSpecimen/ReactSpecimen.js
+++ b/src/specimens/ReactSpecimen/ReactSpecimen.js
@@ -124,4 +124,4 @@ ReactSpecimen.contextTypes = {
   page: CatalogPropTypes.page.isRequired
 };
 
-export default Specimen()(Radium(ReactSpecimen));
+export default Specimen(undefined, undefined, {withChildren: true})(Radium(ReactSpecimen));

--- a/src/utils/__tests__/parseSpecimenBody-test.js
+++ b/src/utils/__tests__/parseSpecimenBody-test.js
@@ -2,7 +2,7 @@ import test from 'tape';
 import {parseSpecimenBody, parseSpecimenYamlBody} from '../parseSpecimenBody';
 
 test('Default String body', (t) => {
-  t.deepEqual(parseSpecimenYamlBody()('foo'), {children: 'foo'});
+  t.deepEqual(parseSpecimenBody()('foo'), {children: 'foo'});
   t.end();
 });
 
@@ -47,7 +47,7 @@ test('body with separator and empty props', (t) => {
 });
 
 test('body with separator and invalid props', (t) => {
-  t.deepEqual(parseSpecimenBody()('foo\n---\nbar'), {children: 'foo\n---\nbar'});
+  t.deepEqual(parseSpecimenBody()('foo\n---\nbar'), {children: 'bar'});
   t.end();
 });
 

--- a/src/utils/__tests__/parseSpecimenBody-test.js
+++ b/src/utils/__tests__/parseSpecimenBody-test.js
@@ -1,28 +1,28 @@
 import test from 'tape';
-import parseSpecimenBody from '../parseSpecimenBody';
+import {parseSpecimenBody, parseSpecimenYamlBody} from '../parseSpecimenBody';
 
 test('Default String body', (t) => {
-  t.deepEqual(parseSpecimenBody()('foo'), {children: 'foo'});
+  t.deepEqual(parseSpecimenYamlBody()('foo'), {children: 'foo'});
   t.end();
 });
 
 test('Default JSON body', (t) => {
-  t.deepEqual(parseSpecimenBody()('{"foo": "bar", "baz": 12.3, "nothing": null, "really": true}'), {foo: 'bar', baz: 12.3, nothing: null, really: true});
+  t.deepEqual(parseSpecimenYamlBody()('{"foo": "bar", "baz": 12.3, "nothing": null, "really": true}'), {foo: 'bar', baz: 12.3, nothing: null, really: true});
   t.end();
 });
 
 test('Default YAML body', (t) => {
-  t.deepEqual(parseSpecimenBody()('foo: bar\nbaz: 12.3\nnothing: null\nreally: true'), {foo: 'bar', baz: 12.3, nothing: null, really: true});
+  t.deepEqual(parseSpecimenYamlBody()('foo: bar\nbaz: 12.3\nnothing: null\nreally: true'), {foo: 'bar', baz: 12.3, nothing: null, really: true});
   t.end();
 });
 
 test('Mapped raw YAML body', (t) => {
-  t.deepEqual(parseSpecimenBody((_, raw) => raw)('foo: bar\nbaz: 12.3\nnothing: null\nreally: true'), 'foo: bar\nbaz: 12.3\nnothing: null\nreally: true');
+  t.deepEqual(parseSpecimenYamlBody((_, raw) => raw)('foo: bar\nbaz: 12.3\nnothing: null\nreally: true'), 'foo: bar\nbaz: 12.3\nnothing: null\nreally: true');
   t.end();
 });
 
 test('Mapped YAML body', (t) => {
-  t.deepEqual(parseSpecimenBody((props) => props.foo)('foo: bar\nbaz: 12.3\nnothing: null\nreally: true'), 'bar');
+  t.deepEqual(parseSpecimenYamlBody((props) => props.foo)('foo: bar\nbaz: 12.3\nnothing: null\nreally: true'), 'bar');
   t.end();
 });
 
@@ -53,6 +53,11 @@ test('body with separator and invalid props', (t) => {
 
 test('body with multiple separators', (t) => {
   t.deepEqual(parseSpecimenBody()('foo: true\n---\nbar\n---\nbaz'), {foo: true, children: 'bar\n---\nbaz'});
+  t.end();
+});
+
+test('body with children but valid yaml', (t) => {
+  t.deepEqual(parseSpecimenBody()('foo: true'), {children: 'foo: true'});
   t.end();
 });
 

--- a/src/utils/__tests__/parseSpecimenBody-test.js
+++ b/src/utils/__tests__/parseSpecimenBody-test.js
@@ -56,6 +56,11 @@ test('body with multiple separators', (t) => {
   t.end();
 });
 
+test('body with trailing separator', (t) => {
+  t.deepEqual(parseSpecimenBody()('foo---\nbar'), {children: 'foo---\nbar'});
+  t.end();
+});
+
 test('body with children but valid yaml', (t) => {
   t.deepEqual(parseSpecimenBody()('foo: true'), {children: 'foo: true'});
   t.end();

--- a/src/utils/parseSpecimenBody.js
+++ b/src/utils/parseSpecimenBody.js
@@ -4,12 +4,16 @@ const yamlOptions = {schema: CORE_SCHEMA};
 
 const defaultMapBodyToProps = (parsedBody, rawBody) => parsedBody || rawBody;
 
-const SPLITTER = '---\n';
+const INITIAL_SEPARATOR = '---\n';
+const SEPARATOR = '\n---\n';
 const splitText = (text) => {
-  const i = text.indexOf(SPLITTER);
+  if (text.indexOf(INITIAL_SEPARATOR) === 0) {
+    return [void 0, text.slice(4)];
+  }
+  const i = text.indexOf(SEPARATOR);
   return i > -1 ?
-    [text.slice(0, i), text.slice(i + 4)] :
-    [(void 0), text];
+    [text.slice(0, i), text.slice(i + 5)] :
+    [void 0, text];
 };
 
 const parseYaml = (str) => {

--- a/src/utils/parseSpecimenBody.js
+++ b/src/utils/parseSpecimenBody.js
@@ -13,11 +13,13 @@ const splitText = (text) => {
 };
 
 const parseYaml = (str) => {
+  let parsed;
   try {
-    return yaml.safeLoad(str, yamlOptions);
+    parsed = yaml.safeLoad(str, yamlOptions);
   } catch (e) {
-    return null;
+    parsed = void 0;
   }
+  return typeof parsed === 'string' ? void 0 : parsed;
 };
 
 export const parseSpecimenYamlBody = (_mapBodyToProps: ?Function) => (body = '') => {
@@ -29,10 +31,5 @@ export const parseSpecimenBody = (_mapBodyToProps: ?Function) => (body = '') => 
   const mapBodyToProps = _mapBodyToProps || defaultMapBodyToProps;
   const splitBody = splitText(body);
   const [props, children] = splitBody;
-  const parsed = parseYaml(props);
-  return typeof parsed === 'string' || parsed === null ? mapBodyToProps({children: body}, body) :
-    mapBodyToProps({...parsed, children}, body);
+  return mapBodyToProps({...parseYaml(props), children}, body);
 };
-
-
-// export default parseSpecimenBody;


### PR DESCRIPTION
Before, any Specimen body which contained valid YAML was parsed. That meant also something like `const foo:Bar = 3;` or `<div style={{fontSize: 30}}>foo</div>` was parsed (because of the `:`)!

This PR introduces two changes to this logic:

1. Specimens which only need YAML (e.g. ColorSpecimen), now use a function which only does that
2. Specimens which contain primarily non-YAML content (e.g. CodeSpecimen) now won't attempt to parse any YAML *unless* they contain a frontmatter-like section separated with `---`. This is similar to before but it's a) *opt-in* for specific specimens and b) *only* content before `---` (if present) will be attempted to be parsed.

Fixes #95. Pinging @wereHamster who reported this.