### PR TITLE
Refactor Catalog context

### DIFF
--- a/src/CatalogPropTypes.js
+++ b/src/CatalogPropTypes.js
@@ -1,6 +1,6 @@
 import {PropTypes} from 'react';
 
-const page = PropTypes.shape({
+export const pageShape = PropTypes.shape({
   title: PropTypes.string.isRequired,
   id: PropTypes.number.isRequired,
   index: PropTypes.number,
@@ -12,9 +12,14 @@ const page = PropTypes.shape({
   imports: PropTypes.object.isRequired
 });
 
-const pages = PropTypes.arrayOf(page);
+export const pagesShape = PropTypes.arrayOf(pageShape);
 
-export default {
-  page,
-  pages
-};
+export const catalogShape = PropTypes.shape({
+  page: pageShape.isRequired,
+  getSpecimen: PropTypes.func.isRequired,
+  theme: PropTypes.object.isRequired,
+  title: PropTypes.string.isRequired,
+  pages: pagesShape.isRequired,
+  pageTree: pagesShape.isRequired,
+  logoSrc: PropTypes.string
+});

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,17 +1,18 @@
 import React, { PropTypes, Children } from 'react';
 import {StyleRoot} from 'radium';
-import CatalogPropTypes from '../../CatalogPropTypes';
+import {catalogShape} from '../../CatalogPropTypes';
 
 import AppLayout from './AppLayout';
 import Menu from '../Menu/Menu';
 
 class App extends React.Component {
   render() {
+    const {catalog, history, location} = this.context;
     return (
       <StyleRoot>
         <AppLayout
-          {...this.context}
-          sideNav={<Menu {...this.context} />}
+          {...catalog}
+          sideNav={<Menu {...catalog} history={history} />}
         >
           {
            Children.only(this.props.children)
@@ -23,14 +24,9 @@ class App extends React.Component {
 }
 
 App.contextTypes = {
-  title: PropTypes.string.isRequired,
-  page: CatalogPropTypes.page.isRequired,
-  pages: CatalogPropTypes.pages.isRequired,
-  pageTree: CatalogPropTypes.pages.isRequired,
-  theme: PropTypes.object.isRequired,
+  catalog: catalogShape.isRequired,
   history: PropTypes.object.isRequired,
-  location: PropTypes.object.isRequired,
-  logoSrc: PropTypes.string
+  location: PropTypes.object.isRequired
 };
 
 App.propTypes = {

--- a/src/components/App/AppLayout.js
+++ b/src/components/App/AppLayout.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import Radium from 'radium';
-import CatalogPropTypes from '../../CatalogPropTypes';
+import {pageShape, pagesShape} from '../../CatalogPropTypes';
 import NavigationBar from './NavigationBar';
 import PageHeader from '../Page/PageHeader';
 
@@ -135,8 +135,8 @@ AppLayout.propTypes = {
   sideNav: PropTypes.node,
   children: PropTypes.node,
   theme: PropTypes.object.isRequired,
-  page: CatalogPropTypes.page.isRequired,
-  pages: CatalogPropTypes.pages.isRequired
+  page: pageShape.isRequired,
+  pages: pagesShape.isRequired
 };
 
 export default Radium(AppLayout);

--- a/src/components/App/NavigationBar.js
+++ b/src/components/App/NavigationBar.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import Radium from 'radium';
-import CatalogPropTypes from '../../CatalogPropTypes';
+import {pageShape} from '../../CatalogPropTypes';
 import Link from '../Link/Link';
 
 function getStyles(theme) {
@@ -127,8 +127,8 @@ class NavigationBar extends React.Component {
 
 NavigationBar.propTypes = {
   theme: PropTypes.object.isRequired,
-  nextPage: CatalogPropTypes.page,
-  previousPage: CatalogPropTypes.page
+  nextPage: pageShape,
+  previousPage: pageShape
 };
 
 export default Radium(NavigationBar);

--- a/src/components/CatalogContext.js
+++ b/src/components/CatalogContext.js
@@ -1,19 +1,21 @@
 import React, {Component, PropTypes, Children} from 'react';
 import App from './App/App';
-import CatalogPropTypes from '../CatalogPropTypes';
+import {catalogShape} from '../CatalogPropTypes';
 
 class CatalogContext extends Component {
   getChildContext() {
     const {title, theme, logoSrc, pages, pageTree, specimens} = this.props.configuration;
     const {router} = this.context;
     return {
-      page: pages.find((p) => router.isActive(p.path)),
-      getSpecimen: (specimen) => specimens[specimen],
-      theme,
-      title,
-      pages,
-      pageTree,
-      logoSrc
+      catalog: {
+        page: pages.find((p) => router.isActive(p.path)),
+        getSpecimen: (specimen) => specimens[specimen],
+        theme,
+        title,
+        pages,
+        pageTree,
+        logoSrc
+      }
     };
   }
 
@@ -34,13 +36,7 @@ CatalogContext.contextTypes = {
 };
 
 CatalogContext.childContextTypes = {
-  title: PropTypes.string.isRequired,
-  theme: PropTypes.object.isRequired,
-  pages: CatalogPropTypes.pages.isRequired,
-  pageTree: CatalogPropTypes.pages.isRequired,
-  page: CatalogPropTypes.page.isRequired,
-  logoSrc: PropTypes.string,
-  getSpecimen: PropTypes.func.isRequired
+  catalog: catalogShape.isRequired
 };
 
 export default function createCatalogContext(config) {

--- a/src/components/Menu/ListItem.js
+++ b/src/components/Menu/ListItem.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import CatalogPropTypes from '../../CatalogPropTypes';
+import {pageShape} from '../../CatalogPropTypes';
 
 import Link from '../Link/Link';
 import NestedList from './NestedList';
@@ -78,7 +78,7 @@ class ListItem extends React.Component {
 }
 
 ListItem.propTypes = {
-  page: CatalogPropTypes.page.isRequired,
+  page: pageShape.isRequired,
   theme: PropTypes.object.isRequired,
   nested: PropTypes.bool,
   history: PropTypes.object.isRequired

--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import CatalogPropTypes from '../../CatalogPropTypes';
+import {pagesShape} from '../../CatalogPropTypes';
 import { heading, text, getFontSize } from '../../styles/typography';
 import Link from '../Link/Link';
 
@@ -77,7 +77,7 @@ class Menu extends React.Component {
 }
 
 Menu.propTypes = {
-  pageTree: CatalogPropTypes.pages.isRequired,
+  pageTree: pagesShape.isRequired,
   theme: PropTypes.object.isRequired,
   logoSrc: PropTypes.string,
   history: PropTypes.object.isRequired,

--- a/src/components/Menu/NestedList.js
+++ b/src/components/Menu/NestedList.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import CatalogPropTypes from '../../CatalogPropTypes';
+import {pagesShape} from '../../CatalogPropTypes';
 
 import Link from '../Link/Link';
 import ListItem, { style as listItemStyle } from './ListItem';
@@ -8,7 +8,7 @@ import Radium from 'radium';
 
 const NestedList = React.createClass({
   propTypes: {
-    pages: CatalogPropTypes.pages.isRequired,
+    pages: pagesShape.isRequired,
     title: PropTypes.string.isRequired,
     theme: PropTypes.object.isRequired,
     history: PropTypes.object.isRequired

--- a/src/components/Page/Page.js
+++ b/src/components/Page/Page.js
@@ -1,4 +1,5 @@
 import React, {Component, PropTypes} from 'react';
+import {catalogShape} from '../../CatalogPropTypes';
 import Radium, {Style} from 'radium';
 import { headingBlock, textBlock, blockquote, unorderedList, orderedList } from '../../styles/typography';
 import renderMarkdown from '../../utils/renderMarkdown';
@@ -8,7 +9,7 @@ import MarkdownSpecimen from '../Specimen/MarkdownSpecimen';
 class Page extends Component {
   render() {
     const {children} = this.props;
-    const {theme} = this.context;
+    const {catalog: {theme, getSpecimen}} = this.context;
 
     const pageStyle = {
       boxSizing: 'border-box',
@@ -35,7 +36,7 @@ class Page extends Component {
               text: child,
               renderer: {
                 code: (body, options) => {
-                  return <MarkdownSpecimen key={getSpecimenKey()} body={body} options={options || ''} />;
+                  return <MarkdownSpecimen key={getSpecimenKey()} body={body} options={options || ''} getSpecimen={getSpecimen} />;
                 }
               }
             }) : child;
@@ -84,7 +85,7 @@ Page.propTypes = {
 };
 
 Page.contextTypes = {
-  theme: PropTypes.object.isRequired
+  catalog: catalogShape.isRequired
 };
 
 export default Radium(Page);

--- a/src/components/Page/PageContentLoader.js
+++ b/src/components/Page/PageContentLoader.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import CatalogPropTypes from '../../CatalogPropTypes';
+import {catalogShape} from '../../CatalogPropTypes';
 
 import Loader from './Loader';
 import PageRenderer from './PageRenderer';
@@ -13,13 +13,13 @@ class PageContentLoader extends Component {
   }
 
   componentWillMount() {
-    this.fetchPageData(this.context.page.src);
+    this.fetchPageData(this.context.catalog.page.src);
   }
 
   componentWillReceiveProps(_, nextContext) {
-    if (nextContext.page.src !== this.context.page.src) {
+    if (nextContext.catalog.page.src !== this.context.catalog.page.src) {
       this.setState({content: null});
-      this.fetchPageData(nextContext.page.src);
+      this.fetchPageData(nextContext.catalog.page.src);
     }
   }
 
@@ -41,7 +41,7 @@ class PageContentLoader extends Component {
 }
 
 PageContentLoader.contextTypes = {
-  page: CatalogPropTypes.page.isRequired
+  catalog: catalogShape.isRequired
 };
 
 export default PageContentLoader;

--- a/src/components/Page/PageRenderer.js
+++ b/src/components/Page/PageRenderer.js
@@ -1,5 +1,5 @@
 import React, {Component, PropTypes} from 'react';
-import CatalogPropTypes from '../../CatalogPropTypes';
+import {catalogShape} from '../../CatalogPropTypes';
 import Page from './Page';
 import runscript from '../../utils/runscript';
 
@@ -11,16 +11,16 @@ const renderContent = (content) => React.isValidElement(content) && content.type
 
 class PageRenderer extends Component {
   componentDidMount() {
-    this.context.page.scripts.forEach(runscript);
+    this.context.catalog.page.scripts.forEach(runscript);
   }
 
   componentDidUpdate() {
-    this.context.page.scripts.forEach(runscript);
+    this.context.catalog.page.scripts.forEach(runscript);
   }
-  
+
   render() {
     const {content} = this.props;
-    const {page: {styles}} = this.context;
+    const {catalog: {page: {styles}}} = this.context;
     return (
       <div>
         {renderStyles(styles)}
@@ -38,7 +38,7 @@ PageRenderer.propTypes = {
 };
 
 PageRenderer.contextTypes = {
-  page: CatalogPropTypes.page.isRequired
+  catalog: catalogShape.isRequired
 };
 
 export default PageRenderer;

--- a/src/components/Specimen/MarkdownSpecimen.js
+++ b/src/components/Specimen/MarkdownSpecimen.js
@@ -6,8 +6,7 @@ const getUnknownSpecimen = (specimenType) => () => <Hint warning>{`Unknown Speci
 
 export default class MarkdownSpecimen extends Component {
   render() {
-    const {options, body} = this.props;
-    const {getSpecimen} = this.context;
+    const {options, body, getSpecimen} = this.props;
     const specimenType = parseSpecimenType(options);
     const Specimen = getSpecimen(specimenType) || getUnknownSpecimen(specimenType);
 
@@ -17,9 +16,6 @@ export default class MarkdownSpecimen extends Component {
 
 MarkdownSpecimen.propTypes = {
   body: PropTypes.string.isRequired,
-  options: PropTypes.string.isRequired
-};
-
-MarkdownSpecimen.contextTypes = {
+  options: PropTypes.string.isRequired,
   getSpecimen: PropTypes.func.isRequired
 };

--- a/src/components/Specimen/Specimen.js
+++ b/src/components/Specimen/Specimen.js
@@ -1,6 +1,7 @@
 // Higher-order Specimen which provides theme
 
 import React, {PropTypes} from 'react';
+import {catalogShape} from '../../CatalogPropTypes';
 import Span from './Span';
 import parseSpecimenOptions from '../../utils/parseSpecimenOptions';
 import parseSpecimenBody from '../../utils/parseSpecimenBody';
@@ -10,7 +11,7 @@ export default function Specimen(mapBodyToProps: Function, mapOptionsToProps: Fu
   const parseBody = parseSpecimenBody(mapBodyToProps);
 
   return (WrappedSpecimen) => {
-    const SpecimenContainer = (props, {theme}) => {
+    const SpecimenContainer = (props, {catalog}) => {
       const {rawOptions, rawBody} = props;
       const optionProps = parseOptions(rawOptions);
       const bodyProps = parseBody(rawBody);
@@ -21,7 +22,7 @@ export default function Specimen(mapBodyToProps: Function, mapOptionsToProps: Fu
           <Span span={span}>
             {bodyProps.map((specimenProps, i) => (
               <Span key={i} span={specimenProps.span}>
-                <WrappedSpecimen {...optionProps} {...specimenProps} {...props}  theme={theme} />
+                <WrappedSpecimen {...optionProps} {...specimenProps} {...props} catalog={catalog} />
               </Span>
             ))}
           </Span>
@@ -30,7 +31,7 @@ export default function Specimen(mapBodyToProps: Function, mapOptionsToProps: Fu
 
       return (
         <Span span={span}>
-          <WrappedSpecimen {...optionProps} {...bodyProps} {...props} theme={theme} />
+          <WrappedSpecimen {...optionProps} {...bodyProps} {...props} catalog={catalog} />
         </Span>
       );
     };
@@ -42,7 +43,7 @@ export default function Specimen(mapBodyToProps: Function, mapOptionsToProps: Fu
     };
 
     SpecimenContainer.contextTypes = {
-      theme: PropTypes.object.isRequired
+      catalog: catalogShape.isRequired
     };
 
     return SpecimenContainer;

--- a/src/specimens/Audio.js
+++ b/src/specimens/Audio.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import {catalogShape} from '../CatalogPropTypes';
 import Radium from 'radium';
 import Specimen from '../components/Specimen/Specimen';
 import Span from '../components/Specimen/Span';
@@ -7,7 +8,7 @@ import {heading} from '../styles/typography';
 
 class Audio extends React.Component {
   render() {
-    const {src, title, loop, autoplay, span, theme} = this.props;
+    const {src, title, loop, autoplay, span, catalog: {theme}} = this.props;
 
     let styles = {
       section: {
@@ -39,7 +40,7 @@ class Audio extends React.Component {
 }
 
 Audio.propTypes = {
-  theme: PropTypes.object.isRequired,
+  catalog: catalogShape.isRequired,
   src: PropTypes.string.isRequired,
   title: PropTypes.string,
   loop: PropTypes.bool,

--- a/src/specimens/Code.js
+++ b/src/specimens/Code.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import {catalogShape} from '../CatalogPropTypes';
 import {text} from '../styles/typography';
 import Radium from 'radium';
 import Specimen from '../components/Specimen/Specimen';
@@ -44,7 +45,7 @@ class Code extends React.Component {
   }
 
   render() {
-    const {theme, children, rawBody, collapsed, lang, raw} = this.props;
+    const {catalog: {theme}, children, rawBody, collapsed, lang, raw} = this.props;
     const {viewSource} = this.state;
     let styles = getStyle(theme);
 
@@ -68,7 +69,7 @@ class Code extends React.Component {
 Code.propTypes = {
   children: PropTypes.string.isRequired,
   rawBody: PropTypes.string.isRequired,
-  theme: PropTypes.object.isRequired,
+  catalog: catalogShape.isRequired,
   collapsed: PropTypes.bool,
   lang: PropTypes.string,
   raw: PropTypes.bool

--- a/src/specimens/Color.js
+++ b/src/specimens/Color.js
@@ -1,10 +1,11 @@
 import React, { PropTypes } from 'react';
+import {catalogShape} from '../CatalogPropTypes';
 import Radium from 'radium';
 import Specimen from '../components/Specimen/Specimen';
 
 class Color extends React.Component {
   render() {
-    const {theme, value, name} = this.props;
+    const {catalog: {theme}, value, name} = this.props;
     let styles = {
       text: {
         fontFamily: theme.fontFamily,
@@ -27,7 +28,7 @@ class Color extends React.Component {
 }
 
 Color.propTypes = {
-  theme: PropTypes.object.isRequired,
+  catalog: catalogShape.isRequired,
   value: PropTypes.string.isRequired,
   name: PropTypes.string
 };

--- a/src/specimens/ColorPalette.js
+++ b/src/specimens/ColorPalette.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import {catalogShape} from '../CatalogPropTypes';
 import Radium from 'radium';
 import Specimen from '../components/Specimen/Specimen';
 
@@ -12,7 +13,7 @@ const ColorPaletteItem = ({name, value, styles}) => (
 
 class ColorPalette extends React.Component {
   render() {
-    const {theme, colors, horizontal} = this.props;
+    const {catalog: {theme}, colors, horizontal} = this.props;
     let styles = {
       container: {
         display: 'flex',
@@ -84,7 +85,7 @@ class ColorPalette extends React.Component {
 }
 
 ColorPalette.propTypes = {
-  theme: PropTypes.object.isRequired,
+  catalog: catalogShape.isRequired,
   colors: PropTypes.arrayOf(PropTypes.shape({
     name: PropTypes.string,
     value: PropTypes.string.isRequired

--- a/src/specimens/Download.js
+++ b/src/specimens/Download.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import {catalogShape} from '../CatalogPropTypes';
 import Radium from 'radium';
 import Specimen from '../components/Specimen/Specimen';
 
@@ -68,7 +69,7 @@ function getStyle(theme) {
 
 class DownloadSpecimen extends React.Component {
   render() {
-    const {theme, title, subtitle, url, filename} = this.props;
+    const {catalog: {theme}, title, subtitle, url, filename} = this.props;
     const styles = getStyle(theme);
     const isHovered = Radium.getState(this.state, null, ':hover');
     const textColor = isHovered ? {color: theme.linkColor} : {};
@@ -97,7 +98,7 @@ DownloadSpecimen.defaultProps = {
 };
 
 DownloadSpecimen.propTypes = {
-  theme: PropTypes.object.isRequired,
+  catalog: catalogShape.isRequired,
   span: PropTypes.number,
   title: PropTypes.string,
   subtitle: PropTypes.string,

--- a/src/specimens/Hint.js
+++ b/src/specimens/Hint.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import {catalogShape} from '../CatalogPropTypes';
 import {Style} from 'radium';
 import renderMarkdown from '../utils/renderMarkdown';
 import Specimen from '../components/Specimen/Specimen';
@@ -37,7 +38,7 @@ function getStyle(theme) {
 
 class Hint extends React.Component {
   render() {
-    const {theme, children, warning, neutral, directive} = this.props;
+    const {catalog: {theme}, children, warning, neutral, directive} = this.props;
     const styles = getStyle(theme);
 
     const warningStyle = warning ? styles.warning : null;
@@ -74,7 +75,7 @@ class Hint extends React.Component {
 
 Hint.propTypes = {
   children: PropTypes.string.isRequired,
-  theme: PropTypes.object.isRequired,
+  catalog: catalogShape.isRequired,
   warning: PropTypes.bool,
   neutral: PropTypes.bool,
   directive: PropTypes.bool

--- a/src/specimens/Html.js
+++ b/src/specimens/Html.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import {catalogShape} from '../CatalogPropTypes';
 import Radium from 'radium';
 import Frame from '../components/Frame/Frame';
 import Specimen from '../components/Specimen/Specimen';
@@ -89,7 +90,7 @@ class Html extends React.Component {
   }
 
   render() {
-    const {theme, children, frame, ...options} = this.props;
+    const {catalog: {theme}, children, frame, ...options} = this.props;
     const styles = getStyle(theme);
     const exampleStyles = {
       ...(options.plain ? styles.plain : null),
@@ -127,7 +128,7 @@ class Html extends React.Component {
 
 Html.propTypes = {
   children: PropTypes.string.isRequired,
-  theme: PropTypes.object.isRequired,
+  catalog: catalogShape.isRequired,
   runScript: PropTypes.bool,
   plain: PropTypes.bool,
   light: PropTypes.bool,

--- a/src/specimens/Image.js
+++ b/src/specimens/Image.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import {catalogShape} from '../CatalogPropTypes';
 import Radium from 'radium';
 import Specimen from '../components/Specimen/Specimen';
 import renderMarkdown from '../utils/renderMarkdown';
@@ -7,7 +8,7 @@ import {text, heading} from '../styles/typography';
 
 class Image extends React.Component {
   render() {
-    const {theme, src, title, overlay, description, ...options} = this.props;
+    const {catalog: {theme}, src, title, overlay, description, ...options} = this.props;
 
     let styles = {
       container: {
@@ -86,7 +87,7 @@ class Image extends React.Component {
 }
 
 Image.propTypes = {
-  theme: PropTypes.object.isRequired,
+  catalog: catalogShape.isRequired,
   src: PropTypes.string.isRequired,
   title: PropTypes.string,
   overlay: PropTypes.string,

--- a/src/specimens/ReactSpecimen/ReactSpecimen.js
+++ b/src/specimens/ReactSpecimen/ReactSpecimen.js
@@ -1,5 +1,5 @@
 import React, { PropTypes, Component } from 'react';
-import CatalogPropTypes from '../../CatalogPropTypes';
+import {catalogShape} from '../../CatalogPropTypes';
 import Radium from 'radium';
 import Frame from '../../components/Frame/Frame';
 import Specimen from '../../components/Specimen/Specimen';
@@ -66,8 +66,7 @@ class ReactSpecimen extends Component {
   }
 
   render() {
-    const {theme, children, noSource, frame, ...options} = this.props;
-    const {page: {imports}} = this.context;
+    const {catalog: {page: {imports}, theme}, children, noSource, frame, ...options} = this.props;
     const styles = getStyle(theme);
 
     const exampleStyles = {
@@ -110,7 +109,7 @@ class ReactSpecimen extends Component {
 }
 
 ReactSpecimen.propTypes = {
-  theme: PropTypes.object.isRequired,
+  catalog: catalogShape.isRequired,
   children: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
   noSource: PropTypes.bool,
   plain: PropTypes.bool,
@@ -118,10 +117,6 @@ ReactSpecimen.propTypes = {
   dark: PropTypes.bool,
   frame: PropTypes.bool,
   state: PropTypes.object
-};
-
-ReactSpecimen.contextTypes = {
-  page: CatalogPropTypes.page.isRequired
 };
 
 export default Specimen()(Radium(ReactSpecimen));

--- a/src/specimens/Type.js
+++ b/src/specimens/Type.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import {catalogShape} from '../CatalogPropTypes';
 import Specimen from '../components/Specimen/Specimen';
 
 function getStyle(theme) {
@@ -47,7 +48,7 @@ const kafka = `One morning, when Gregor Samsa woke from troubled dreams, he foun
 
 class Type extends React.Component {
   render() {
-    const {theme, ...options} = this.props;
+    const {catalog: {theme}, ...options} = this.props;
     let styles = getStyle(theme);
 
     // check if a shorter paragraph should is demanded
@@ -138,7 +139,7 @@ Type.propTypes = {
   image: PropTypes.string,
   headings: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
   paragraphs: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
-  theme: PropTypes.object.isRequired
+  catalog: catalogShape.isRequired
 };
 
 export default Specimen()(Type);

--- a/src/specimens/Video.js
+++ b/src/specimens/Video.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import {catalogShape} from '../CatalogPropTypes';
 import Radium from 'radium';
 import Specimen from '../components/Specimen/Specimen';
 
@@ -6,7 +7,7 @@ import {heading} from '../styles/typography';
 
 class Video extends React.Component {
   render() {
-    const {src, title, muted, loop, autoplay, theme} = this.props;
+    const {src, title, muted, loop, autoplay, catalog: {theme}} = this.props;
 
     let styles = {
       section: {
@@ -45,7 +46,7 @@ class Video extends React.Component {
 }
 
 Video.propTypes = {
-  theme: PropTypes.object.isRequired,
+  catalog: catalogShape.isRequired,
   src: PropTypes.string.isRequired,
   title: PropTypes.string,
   muted: PropTypes.bool,


### PR DESCRIPTION
We now define only one `catalog` context object (which contains all previously defined context props). This makes Catalog a better citizen because it doesn't pollute context anymore and it's clearer which context props belong to which library.

Specimens now don't have to use context at all because the current catalog context object will be passed as a prop to them. Before they just received `theme` as a prop which wasn't enough for `ReactSpecimen`. This opens the door for more advanced specimens and also makes them easier to test (once we get to that).

This shouldn't break break anything for users because context is just used internally.