### PR TITLE
Update React Router and scroll behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "scripts": {},
   "dependencies": {
     "babel-standalone": "^6.7.4",
+    "history": "^2.0.0",
     "isomorphic-fetch": "^2.2.0",
     "js-yaml": "^3.4.3",
     "marked": "^0.3.2",
@@ -33,13 +34,12 @@
     "radium": "^0.17.1",
     "raf": "^3.1.0",
     "ramda": "^0.21.0",
-    "scroll-behavior": "^0.4.0"
+    "react-router-scroll": "^0.2.0",
+    "react-router": "^2.4.0"
   },
   "peerDependencies": {
     "react": ">=0.14.0",
-    "react-dom": ">=0.14.0",
-    "react-router": "^2.0.0",
-    "history": "^2.0.0"
+    "react-dom": ">=0.14.0"
   },
   "devDependencies": {
     "assign-deep": "^0.4.2",
@@ -63,14 +63,12 @@
     "express": "^4.13.3",
     "faucet": "0.0.1",
     "gh-pages": "^0.11.0",
-    "history": "^2.0.0",
     "nodemon": "^1.8.1",
     "object-values": "^1.0.0",
     "portfinder": "^1.0.0",
     "raw-loader": "^0.5.1",
     "react": "^15.0.1",
     "react-dom": "^15.0.1",
-    "react-router": "^2.0.0",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.1",
     "redbox-react": "^1.1.1",

--- a/src/render.js
+++ b/src/render.js
@@ -1,19 +1,19 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {Router, useRouterHistory} from 'react-router';
+import {Router, useRouterHistory, applyRouterMiddleware} from 'react-router';
 import {createHashHistory} from 'history';
-import useScroll from 'scroll-behavior/lib/useSimpleScroll';
+import useScroll from 'react-router-scroll';
 import seqKey from './utils/seqKey';
 
 import configureRoutes from './configureRoutes';
 
-const history = useRouterHistory(useScroll(createHashHistory))({queryKey: false});
+const history = useRouterHistory(createHashHistory)({queryKey: false});
 
 const getKey = seqKey('CatalogRouter');
 
 export default (config, element) => {
   ReactDOM.render(
-    <Router key={getKey()} history={history} routes={configureRoutes(config)} />,
+    <Router key={getKey()} history={history} routes={configureRoutes(config)} render={applyRouterMiddleware(useScroll())} />,
     element
   );
 };


### PR DESCRIPTION
Uses the new https://github.com/taion/react-router-scroll router middleware for more reliable scroll handling. This needs react-router@2.3, so I've bumped the required version.

I also moved react-router and history to dependencies, so it's less of a hassle to install Catalog. I'm not 100% sure if this works with `configureRoutes` and older react-router versions though.