### PR TITLE
Dynamic document title

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,9 @@
     "radium": "^0.17.1",
     "raf": "^3.1.0",
     "ramda": "^0.21.0",
-    "react-router-scroll": "^0.2.0",
-    "react-router": "^2.4.0"
+    "react-document-title": "^2.0.1",
+    "react-router": "^2.4.0",
+    "react-router-scroll": "^0.2.0"
   },
   "peerDependencies": {
     "react": ">=0.14.0",

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,15 +1,23 @@
 import React, { PropTypes, Children } from 'react';
 import {StyleRoot} from 'radium';
+import DocumentTitle from 'react-document-title';
 import {catalogShape} from '../../CatalogPropTypes';
 
 import AppLayout from './AppLayout';
 import Menu from '../Menu/Menu';
+
+const getDocumentTitle = ({title, page}) => title === page.superTitle ?
+  `${page.superTitle} – ${page.title}` :
+  `${title} – ${page.superTitle} – ${page.title}`;
 
 class App extends React.Component {
   render() {
     const {catalog, history, location} = this.context;
     return (
       <StyleRoot>
+        <DocumentTitle
+          title={getDocumentTitle(catalog)}
+        />
         <AppLayout
           {...catalog}
           sideNav={<Menu {...catalog} history={history} />}


### PR DESCRIPTION
Modifies the document title to match the current page's title. E.g.

- Catalog – Overview
- Catalog – Specimens – React

[react-helmet](https://github.com/nfl/react-helmet) would be a more complete solution but adds another 10KB to the minified bundle compared to [react-document-title](https://github.com/gaearon/react-document-title).

Fixes #119