### PR TITLE
Add Catalog component

### DIFF
--- a/docs/basics/configuration.md
+++ b/docs/basics/configuration.md
@@ -28,7 +28,9 @@ You should at least have a page with path `'/'` (which is the first page shown)
 
 #### Page Example
 
-```
+```code
+lang: js
+---
 {
   title: 'My Catalog',
   pages: [
@@ -44,7 +46,7 @@ You should at least have a page with path `'/'` (which is the first page shown)
 
 ### React Component Pages
 
-When integrating Catalog in a React project, you can directly use components as page content. This leads to better performance (the content doesn't have to be loaded and transformed first) and better integration with your development setup. For example, if you have configured hot reloading with webpack, you can edit your documentation and see changes immediately without having to reload your browser.
+When [integrating Catalog in a React project](/react-integration), you can directly use components as page content. This leads to better performance (the content doesn't have to be loaded and transformed first) and better integration with your development setup. For example, if you have configured hot reloading with webpack, you can edit your documentation and see changes immediately without having to reload your browser.
 
 #### Component Page Properties
 
@@ -54,34 +56,16 @@ When integrating Catalog in a React project, you can directly use components as 
 
 #### Component Page Example
 
-```
+```code
+lang: js
+---
 {
   title: 'My Catalog',
   pages: [
     {
       path: '/',
       title: 'Introduction',
-      component: require('Intro') // `Intro` is a module which exports a React component
-    },
-    // Other pages …
-  ]
-}
-```
-
-#### Component Page Example (with Webpack Loader)
-
-```hint|directive
-Catalog includes a **webpack loader** which transforms Markdown files into hot-reloadable page components.
-```
-
-```
-{
-  title: 'My Catalog',
-  pages: [
-    {
-      path: '/',
-      title: 'Introduction',
-      component: require('catalog/lib/loader!raw!intro.md') // `intro.md` is a regular Markdown file
+      component: Introduction // `Introduction` is a module which exports a React component
     },
     // Other pages …
   ]

--- a/docs/basics/get-started.md
+++ b/docs/basics/get-started.md
@@ -44,7 +44,7 @@ If you don't have an existing server for your project, use something simple like
 python -m SimpleHTTPServer
 ```
 
-## npm
+## npm Module
 
 The npm module of Catalog can be integrated into your React application, so you can develop your components directly in your styleguide.
 

--- a/docs/basics/get-started.md
+++ b/docs/basics/get-started.md
@@ -57,19 +57,24 @@ npm install catalog react react-dom --save
 Import Catalog, and render it.
 
 ```code|lang-js
-import {render} from 'catalog';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {Catalog} from 'catalog';
 
-render({
-  title: 'My Catalog',
-  pages: [
-    {
-      path: '/',                     // The path where the page can be accessed
-      title: 'Introduction',         // The page title
-      component: require('Intro')    // The documenation component
-    },
-    // Other pages …
-  ]
-}, document.getElementById('app'));
+ReactDOM.render(
+  <Catalog
+    title='My Catalog'
+    pages={[
+      {
+        path: '/',                     // The path where the page can be accessed
+        title: 'Introduction',         // The page title
+        component: require('Intro')    // The documenation component
+      },
+      // Other pages …
+    ]}
+  />,
+  document.getElementById('app')
+);
 ```
 
 See the [React Integration](/react-integration) guide for more details.

--- a/docs/react-integration.md
+++ b/docs/react-integration.md
@@ -1,5 +1,9 @@
 > With Catalog you can develop React components directly in your style guide, enable hot-reloading documentation writing, and integrate Catalog in an existing application.
 
+```hint
+This section assumes that you have a working development setup with npm, webpack and a ES2015 transpiler (for example Babel).
+```
+
 ## Catalog React Component
 
 Catalog exports a `Catalog` React component. You can render it as the root element or compose it in other components.
@@ -51,7 +55,7 @@ The Catalog webpack loader turns Markdown files into React components. Use `comp
 ```
 
 ```code|lang-jsx
-const Introduction = require('catalog/lib/loader!raw!./Introduction.md')
+import Introduction from 'catalog/lib/loader!raw!./Introduction.md';
 
 <Catalog
   title='My Styleguide'

--- a/docs/react-integration.md
+++ b/docs/react-integration.md
@@ -1,62 +1,109 @@
-> The npm module of Catalog can be integrated into your React application, so you can develop your components directly in your styleguide.
+> With Catalog you can develop React components directly in your style guide, enable hot-reloading documentation writing, and integrate Catalog in an existing application.
 
-## Usage
+## Catalog React Component
 
-### Standalone
+Catalog exports a `Catalog` React component. You can render it as the root element or compose it in other components.
+
+The `Catalog` component takes all [configuration](/configuration) options as **props**.
 
 ```code|lang-jsx
-import {render} from 'catalog';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {Catalog} from 'catalog';
+
 import Intro from './docs/Intro';
 import ButtonDocs from './docs/Buttons';
 import GridDocs from './docs/Grids';
 
-render({
-  title: 'My Styleguide',
-  basePath: '/catalog',
-  pages: [
+ReactDOM.render(
+  <Catalog
+    title='My Styleguide'
+    basePath='/catalog'
+    pages={[
+      {
+        path: '/',
+        title: 'Introduction',
+        component: Intro
+      },
+      {
+        title: 'Components',
+        pages: [
+          {path: 'buttons', title: 'Buttons', component: ButtonDocs},
+          {path: 'grid', title: 'Grid', component: GridDocs}
+        ]
+      }
+    ]}
+  />,
+  document.getElementById('app')
+);
+```
+
+## Hot Reloadable Markdown Files
+
+Catalog provides a [webpack](http://webpack.github.io/) loader which allows you to import hot-reloadable Markdown files.
+
+Also install webpack's `raw-loader` with `npm install raw-loader --save-dev`
+
+You need to make sure that your app has hot module replacement enabled. See [Dan Abramov's react-hot-boilerplate](https://github.com/gaearon/react-hot-boilerplate) for a starting point.
+
+```hint|directive
+The Catalog webpack loader turns Markdown files into React components. Use `component` instead of `src` in the page configuration.
+```
+
+```code|lang-jsx
+const Introduction = require('catalog/lib/loader!raw!./Introduction.md')
+
+<Catalog
+  title='My Styleguide'
+  pages={[
     {
       path: '/',
       title: 'Introduction',
-      component: Intro
+      component: Introduction     // <- Use `component` instead of `src`
     },
-    {
-      title: 'Components',
-      pages: [
-        {path: 'buttons', title: 'Buttons', component: ButtonDocs},
-        {path: 'grid', title: 'Grid', component: GridDocs}
-      ]
-    }
-  ]
-}, document.getElementById('app'));
+    // ...
+  ]}
+/>
 ```
 
-### With React Router
+To save you from prepending `catalog/lib/loader!raw!` to each import, you can also put this in your webpack configuration file:
 
-Instead of directly rendering, Catalog can provide its routes to mix them with your existing ones.
+```code|lang-javascript
+{
+  // Other webpack config ...
+  module: {
+    loaders: [
+      {
+        test: /\.md$/,
+        loaders: ['catalog/lib/loader', 'raw']
+      }
+    ]
+  }
+};
+```
+
+## Advanced Integration
+
+> If you need more control over the integration into your application, Catalog is flexible enough to supports some advanced use cases.
+
+### React Router Routes
+
+The `Catalog` component creates routes and renders React Router with a few presets internally. But with `configureRoutes` you can also generate Catalog routes, so you can
+
+- mix them with other routes,
+- use them for server-side rendering,
+- configure `Router` however you like.
 
 ```code|lang-jsx
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {Router} from 'react-router';
 import {configureRoutes} from 'catalog';
-import Intro from './docs/Intro';
-import ButtonDocs from './docs/Buttons';
-import GridDocs from './docs/Grids';
 
 const catalogRoutes = configureRoutes({
   title: 'My Styleguide',
   basePath: '/catalog',
-  pages: [
-    {
-      path: '/',
-      title: 'Introduction',
-      component: Intro
-    }
-    {
-      title: 'Components',
-      pages: [
-        {path: 'buttons', title: 'Buttons', component: ButtonDocs},
-        {path: 'grid', title: 'Grid', component: GridDocs}
-      ]
-    }
-  ]
+  pages: [/* ... */]
 });
 
 const routes = [
@@ -65,18 +112,27 @@ const routes = [
 ];
 
 
-ReactDOM.render(<Router routes={routes} />, document.getElementById('app'));
+ReactDOM.render(
+  <Router routes={routes} />,
+  document.getElementById('app')
+);
 ```
 
-## Writing Documentation
+### Write Documentation with React Components
 
-Instead of using Markdown files, you can use Catalog's components directly. This allows you to write your documentation in a relatively concise way while maintaining maximal flexibility.
+Instead of using Markdown files, you can use Catalog's `Page` and all specimen components directly to create your own page components. This enables you for example to
 
-If you provide these components to the configuration (see above), they will display nicely as individual pages.
+- generate documentation programmatically,
+- mix specimens with other components,
+- or share state across specimens.
+
+```hint|directive
+As with the webpack loader transformed Markdown files, use `component` instead of `src` in the page configuration.
+```
 
 ```code|lang-jsx
 import React from 'react';
-import {Page, ReactSpecimen} from 'catalog';
+import {Page, ReactSpecimen, ColorPaletteSpecimen} from 'catalog';
 import Button from 'components/Button/Button';
 
 export default () => (
@@ -93,35 +149,10 @@ export default () => (
     <hr />
 
     <ReactSpecimen span={3}>
-      <Button primary>Foo</Button>
+      {'<Button primary>Foo</Button>'}
     </ReactSpecimen>
 
-    <ReactSpecimen span={3}>
-      <Button disabled>Foo</Button>
-    </ReactSpecimen>
-
-    <ReactSpecimen span={3}>
-      <Button disabled primary>Foo</Button>
-    </ReactSpecimen>
+    <ColorPaletteSpecimen span={3} colors={generateColorPalette()}>
   </Page>
 );
-```
-
-## Webpack Loader
-
-Catalog provides a loader which allows you to import hot-reloadable Markdown files.
-
-```code|lang-javascript
-{
-  // Other webpack config ...
-  module: {
-    loaders: [
-      {
-        test: /\.md$/,
-        loaders: ['catalog/lib/loader', 'raw']
-      }
-    ]
-  }
-};
-
 ```

--- a/examples/catalog-module/index.js
+++ b/examples/catalog-module/index.js
@@ -1,13 +1,20 @@
-import {render} from '../../src/index';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {Catalog} from '../../src/index';
 
-render({
-  title: 'My Components',
-  pages: [
-    {
-      path: '/',
-      title: 'Foo',
-      imports: {Foo: require('./components/Foo/Foo')},
-      component: require('./components/Foo/Foo.docs.md')
-    }
-  ]
-}, document.getElementById('app'));
+ReactDOM.render(
+  <Catalog
+    configuration={{
+      title: 'My Components',
+      pages: [
+        {
+          path: '/',
+          title: 'Foo',
+          imports: {Foo: require('./components/Foo/Foo')},
+          component: require('./components/Foo/Foo.docs.md')
+        }
+      ]
+    }} 
+  />,
+  document.getElementById('app')
+);

--- a/examples/catalog-module/index.js
+++ b/examples/catalog-module/index.js
@@ -4,17 +4,15 @@ import {Catalog} from '../../src/index';
 
 ReactDOM.render(
   <Catalog
-    configuration={{
-      title: 'My Components',
-      pages: [
-        {
-          path: '/',
-          title: 'Foo',
-          imports: {Foo: require('./components/Foo/Foo')},
-          component: require('./components/Foo/Foo.docs.md')
-        }
-      ]
-    }} 
+    title='My Components'
+    pages={[
+      {
+        path: '/',
+        title: 'Foo',
+        imports: {Foo: require('./components/Foo/Foo')},
+        component: require('./components/Foo/Foo.docs.md')
+      }
+    ]}
   />,
   document.getElementById('app')
 );

--- a/src/components/Catalog.js
+++ b/src/components/Catalog.js
@@ -1,12 +1,12 @@
-import React, {Component} from 'react';
-import {Router, useRouterHistory, applyRouterMiddleware} from 'react-router';
+import React, {Component, PropTypes} from 'react';
+import {Router, useRouterHistory, applyRouterMiddleware, browserHistory} from 'react-router';
 import {createHashHistory} from 'history';
 import useScroll from 'react-router-scroll';
 import seqKey from '../utils/seqKey';
 
 import configureRoutes from '../configureRoutes';
 
-const history = useRouterHistory(createHashHistory)({queryKey: false});
+const hashHistory = useRouterHistory(createHashHistory)({queryKey: false});
 
 export default class Catalog extends Component {
   constructor() {
@@ -22,10 +22,19 @@ export default class Catalog extends Component {
     });
   }
   render() {
-    const configuration = this.props;
+    const {useBrowserHistory, ...configuration} = this.props;
     const {routerKey} = this.state;
     return (
-      <Router key={routerKey} history={history} routes={configureRoutes(configuration)} render={applyRouterMiddleware(useScroll())} />
+      <Router
+        key={routerKey}
+        history={useBrowserHistory ? browserHistory : hashHistory}
+        routes={configureRoutes(configuration)}
+        render={applyRouterMiddleware(useScroll())}
+      />
     );
   }
 }
+
+Catalog.propTypes = {
+  useBrowserHistory: PropTypes.bool
+};

--- a/src/components/Catalog.js
+++ b/src/components/Catalog.js
@@ -1,0 +1,35 @@
+import React, {Component, PropTypes} from 'react';
+import {Router, useRouterHistory, applyRouterMiddleware} from 'react-router';
+import {createHashHistory} from 'history';
+import useScroll from 'react-router-scroll';
+import seqKey from '../utils/seqKey';
+
+import configureRoutes from '../configureRoutes';
+
+const history = useRouterHistory(createHashHistory)({queryKey: false});
+
+export default class Catalog extends Component {
+  constructor() {
+    super();
+    this.getKey = seqKey('CatalogRouter');
+    this.state = {
+      routerKey: this.getKey()
+    };
+  }
+  componentWillReceiveProps() {
+    this.setState({
+      routerKey: this.getKey()
+    });
+  }
+  render() {
+    const {configuration} = this.props;
+    const {routerKey} = this.state;
+    return (
+      <Router key={routerKey} history={history} routes={configureRoutes(configuration)} render={applyRouterMiddleware(useScroll())} />
+    );
+  }
+}
+
+Catalog.propTypes = {
+  configuration: PropTypes.object.isRequired
+};

--- a/src/components/Catalog.js
+++ b/src/components/Catalog.js
@@ -1,4 +1,4 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
 import {Router, useRouterHistory, applyRouterMiddleware} from 'react-router';
 import {createHashHistory} from 'history';
 import useScroll from 'react-router-scroll';
@@ -22,14 +22,10 @@ export default class Catalog extends Component {
     });
   }
   render() {
-    const {configuration} = this.props;
+    const configuration = this.props;
     const {routerKey} = this.state;
     return (
       <Router key={routerKey} history={history} routes={configureRoutes(configuration)} render={applyRouterMiddleware(useScroll())} />
     );
   }
 }
-
-Catalog.propTypes = {
-  configuration: PropTypes.object.isRequired
-};

--- a/src/index-standalone.js
+++ b/src/index-standalone.js
@@ -8,6 +8,7 @@ export {default as configureRoutes} from './configureRoutes';
 export {configureJSXRoutes as configureJSXRoutes} from './configureRoutes';
 
 // Components
+export {default as Catalog} from './components/Catalog';
 export {default as Card} from './components/Card/Card';
 export {default as Page} from './components/Page/Page';
 export {default as Span} from './components/Specimen/Span';

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ export {default as configureRoutes} from './configureRoutes';
 export {configureJSXRoutes as configureJSXRoutes} from './configureRoutes';
 
 // Components
+export {default as Catalog} from './components/Catalog';
 export {default as Card} from './components/Card/Card';
 export {default as Page} from './components/Page/Page';
 export {default as Span} from './components/Specimen/Span';

--- a/src/render.js
+++ b/src/render.js
@@ -1,19 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {Router, useRouterHistory, applyRouterMiddleware} from 'react-router';
-import {createHashHistory} from 'history';
-import useScroll from 'react-router-scroll';
-import seqKey from './utils/seqKey';
+import Catalog from './components/Catalog';
 
-import configureRoutes from './configureRoutes';
-
-const history = useRouterHistory(createHashHistory)({queryKey: false});
-
-const getKey = seqKey('CatalogRouter');
-
-export default (config, element) => {
+export default (configuration, element) => {
   ReactDOM.render(
-    <Router key={getKey()} history={history} routes={configureRoutes(config)} render={applyRouterMiddleware(useScroll())} />,
+    <Catalog configuration={configuration} />,
     element
   );
 };

--- a/src/render.js
+++ b/src/render.js
@@ -4,7 +4,7 @@ import Catalog from './components/Catalog';
 
 export default (configuration, element) => {
   ReactDOM.render(
-    <Catalog configuration={configuration} />,
+    <Catalog {...configuration} />,
     element
   );
 };


### PR DESCRIPTION
Wraps `Router` initialization and route configuration in the `Catalog` component. This _should_ improve composability in existing apps which may not use react-router themselves (see #93).

I don't know if this is such a great idea. Since it's a small addition to the external API and doesn't prevent more low-level integration in apps I don't think this would hurt too much. I'm still hesitant to add this, especially if it doesn't solve any real problems.

One thing this _could_ potentially enable is adding a configuration switch between `hashHistory` (currently the only way Catalog does routing unless you use `configureRoutes` and configure the router yourself) and `browserHistory`. I.e. `<Catalog configuration={{browserHistory: true, ...}} />` or pass in your own `history`, but then what's the point of not using react-router yourself …

@swissmanu: Is this what you need? I didn't manage to talk to @wereHamster about this, so I'm fishing a bit in the dark here 😄. This doesn't really decouple from react-router but treats it more as an implementation detail. So if you'd render `<Catalog configuration={...} />` with your own router, Catalog's internal instance of react-router would take over the routing from there.

