### PR TITLE
Allow injecting data to layout

### DIFF
--- a/docs/basics/configuration.md
+++ b/docs/basics/configuration.md
@@ -46,6 +46,19 @@ The title of your Catalog
 
 Catalog pages need at least three properties:
 
+### Injecting
+
+To `inject` information for each page, configure as follows:
+
+```
+{
+  inject: () => <div>demo</div>,
+  title: 'My Catalog',
+  ...
+}
+```
+
+`inject` accepts something that React can render. The injected code will appear on every page of the catalog. This is handy for attaching GitHub fork widgets etc.
 
 ##### Page Properties
 

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
   <script src="catalog.js"></script>
   <script>
     Catalog.render({
-      inject: function inject() { return React.createElement('div', {}, 'demo'); },
+      inject: function inject() { console.log('injecting'); return null; },
       title: "Catalog",
       logoSrc: "docs/assets/catalog_logo.svg",
       theme: {

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-53158985-1', 'auto');
-      ga('send', 'pageview');      
+      ga('send', 'pageview');
     }
   </script>
 </head>
@@ -24,6 +24,7 @@
   <script src="catalog.js"></script>
   <script>
     Catalog.render({
+      inject: function inject() { return React.createElement('div', {}, 'demo'); },
       title: "Catalog",
       logoSrc: "docs/assets/catalog_logo.svg",
       theme: {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint": "^3.0.0",
     "eslint-config-interactivethings": "^3.0.0-beta.3",
     "eslint-plugin-react": "^5.1.1",
+    "expose-loader": "^0.7.1",
     "express": "^4.13.3",
     "faucet": "0.0.1",
     "gh-pages": "^0.11.0",

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -23,6 +23,9 @@ class App extends React.Component {
           sideNav={<Menu {...catalog} history={history} />}
         >
           {
+           catalog.inject && catalog.inject()
+          }
+          {
            Children.only(this.props.children)
           }
         </AppLayout>

--- a/src/components/CatalogContext.js
+++ b/src/components/CatalogContext.js
@@ -6,13 +6,14 @@ const fallbackPathRe = /\*$/;
 
 class CatalogContext extends Component {
   getChildContext() {
-    const {title, theme, logoSrc, pages, pageTree, specimens, basePath} = this.props.configuration;
+    const {inject, title, theme, logoSrc, pages, pageTree, specimens, basePath} = this.props.configuration;
     const {router} = this.context;
     return {
       catalog: {
         page: pages.find((p) => router.isActive(p.path) || fallbackPathRe.test(p.path)),
         getSpecimen: (specimen) => specimens[specimen],
         theme,
+        inject,
         title,
         pages: pages.filter((p) => !p.hideFromMenu),
         pageTree,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,8 @@ module.exports = {
   },
   module: {
     loaders: [
-      {test: /\.js$/, include: resolveHere('src'), loader: 'babel'}
+      {test: /\.js$/, include: resolveHere('src'), loader: 'babel'},
+      {test: require.resolve('react'), loader: 'expose?React'}
     ],
     noParse: /\.min\.js$/
   },


### PR DESCRIPTION
The idea of this little PR is to allow the user to `inject` data to each page. I'll use this for injecting a Github fork widget though there might be other uses.

If you can provide some other way to customize layout, this PR will likely become redundant. Just thought to PR given I got it to work.