### PR TITLE
Improve image specimen descriptions

### DIFF
--- a/docs/specimens/image.md
+++ b/docs/specimens/image.md
@@ -17,23 +17,170 @@ The `src` and `overlay` keys accept the `srcSet` notation, which allows the usag
 
 ### Examples
 
+#### Styles
+
+```image
+light: true
+span: 3
+src: "docs/assets/catalog_logo.png"
+```
+
+````code|span-3
+```image
+light: true
+span: 3
+src: "docs/assets/catalog_logo.png"
+```
+````
+
+```image
+dark: true
+span: 3
+src: "docs/assets/catalog_logo--white.png"
+```
+
+````code|span-3
+```image
+dark: true
+span: 3
+src: "docs/assets/catalog_logo--white.png"
+```
+````
+
+```image
+plain: true
+span: 3
+src: "docs/assets/catalog_logo.png"
+```
+
+````code|span-3
+```image
+plain: true
+span: 2
+src: "docs/assets/catalog_logo.png"
+```
+````
+
+```image
+light: true
+plain: true
+span: 3
+src: "docs/assets/catalog_logo.png"
+```
+
+````code|span-3
+```image
+light: true
+plain: true
+span: 3
+src: "docs/assets/catalog_logo.png"
+```
+````
+
+```image
+dark: true
+plain: true
+span: 3
+src: "docs/assets/catalog_logo--white.png"
+```
+
+````code|span-3
+```image
+dark: true
+plain: true
+span: 3
+src: "docs/assets/catalog_logo--white.png"
+```
+````
+
+#### Title and description
+
+```image
+span: 3
+src: "docs/assets/catalog_logo.png"
+title: "Catalog Logo"
+description: |
+  The quick brown fox
+  jumps over
+  multiple lines
+```
+
+````code|span-3
+```image
+span: 3
+src: "docs/assets/catalog_logo.png"
+title: "Catalog Logo"
+description: |
+  The quick brown fox
+  jumps over
+  multiple lines
+```
+````
+
+```image
+span: 3
+dark: true
+src: "docs/assets/catalog_logo--white.png"
+title: "Catalog Logo"
+description: |
+  The quick brown fox
+  jumps over
+  multiple lines
+```
+
+````code|span-3
+```image
+span: 3
+dark: true
+src: "docs/assets/catalog_logo--white.png"
+title: "Catalog Logo"
+description: |
+  The quick brown fox
+  jumps over
+  multiple lines
+```
+````
+
+```image
+span: 3
+plain: true
+src: "docs/assets/catalog_logo.png"
+title: "Catalog Logo"
+description: |
+  The quick brown fox
+  jumps over
+  multiple lines
+```
+
+````code|span-3
+```image
+span: 3
+plain: true
+src: "docs/assets/catalog_logo.png"
+title: "Catalog Logo"
+description: |
+  The quick brown fox
+  jumps over
+  multiple lines
+```
+````
+
 #### Hero image
 
 By using a plain background and no title you can place a simple image.
 
-```image|plain
-{
-    "src": "docs/assets/image_bw.jpg"
-}
+```image
+plain: true
+src: "docs/assets/image_bw.jpg"
+description: _Example image by [unsplash](https://unsplash.com/photos/-YMhg0KYgVc)._
 ```
 
-_Example image by [unsplash](https://unsplash.com/photos/-YMhg0KYgVc)._
 
-````code|lang-javascript
-```image|plain
-{
-    "src": "docs/assets/image_bw.jpg"
-}
+
+````code
+```image
+plain: true
+src: "docs/assets/image_bw.jpg"
 ```
 ````
 
@@ -43,69 +190,18 @@ _Example image by [unsplash](https://unsplash.com/photos/-YMhg0KYgVc)._
 The overlay image is useful to document layout measurements for implementation.
 
 ```image
-{   
-    "src": "docs/assets/catalog_logo.png",
-    "overlay": "docs/assets/catalog_logo-overlay.png"
-}
+src: "docs/assets/catalog_logo.png"
+overlay: "docs/assets/catalog_logo-overlay.png"
 ```
 
-````code|lang-javascript
+````code
 ```image
-{   
-    "src": "docs/assets/catalog_logo.png",
-    "overlay": "docs/assets/catalog_logo-overlay.png"
-}
+src: "docs/assets/catalog_logo.png"
+overlay: "docs/assets/catalog_logo-overlay.png"
 ```
 ````
 
 
 
-#### Image with details
 
-By adding attributes it is possible to specify implementation details.
 
-```image|dark
-{
-    "src": "docs/assets/catalog_logo.png",
-    "description": "alt text: catalog logo, add .2s fade in animation",
-    "title": "Catalog Logo"
-}
-```
-
-````code|lang-javascript
-```image|dark
-{
-    "src": "docs/assets/catalog_logo.png",
-    "description": "alt text: catalog logo, add .2s fade in animation",
-    "title": "Catalog Logo"
-}
-```
-````
-
-#### Multiple images
-
-```image|span-5
-{
-    "src": "docs/assets/catalog_logo.png",
-}
-```
-
-```image|span-1
-{
-    "src": "docs/assets/catalog_logo.png",
-}
-```
-
-````code|lang-javascript
-```image|span-5
-{
-    "src": "docs/assets/catalog_logo.png",
-}
-```
-
-```image|span-1
-{
-    "src": "docs/assets/catalog_logo.png",
-}
-```
-````

--- a/docs/specimens/image.md
+++ b/docs/specimens/image.md
@@ -172,7 +172,7 @@ By using a plain background and no title you can place a simple image.
 ```image
 plain: true
 src: "docs/assets/image_bw.jpg"
-description: _Example image by [unsplash](https://unsplash.com/photos/-YMhg0KYgVc)._
+description: "_Example image by [unsplash](https://unsplash.com/photos/-YMhg0KYgVc)._"
 ```
 
 
@@ -181,6 +181,7 @@ description: _Example image by [unsplash](https://unsplash.com/photos/-YMhg0KYgV
 ```image
 plain: true
 src: "docs/assets/image_bw.jpg"
+description: "_Example image by [unsplash](https://unsplash.com/photos/-YMhg0KYgVc)._"
 ```
 ````
 

--- a/src/specimens/Image.js
+++ b/src/specimens/Image.js
@@ -1,6 +1,6 @@
 import React, {PropTypes} from 'react';
 import {catalogShape} from '../CatalogPropTypes';
-import Radium from 'radium';
+import Radium, {Style} from 'radium';
 import Specimen from '../components/Specimen/Specimen';
 import renderMarkdown from '../utils/renderMarkdown';
 
@@ -33,25 +33,19 @@ class Image extends React.Component {
         }
       },
       title: {
-        ...heading(theme, {level: 6}),
-        margin: 0
-      },
-      truncate: {
-        maxWidth: '100%',
-        textOverflow: 'ellipsis',
-        whiteSpace: 'nowrap',
-        overflow: 'hidden'
+        ...heading(theme, 0),
+        fontWeight: 700,
+        margin: `20px 0 0 0`
       },
       description: {
-        ...text(theme, {level: 2}),
-        marginTop: 5
+        ...text(theme, -1),
+        margin: `20px 0 0 0`
       },
       light: {
         background: `url(${theme.checkerboardPatternLight})`
       },
       dark: {
-        background: `url(${theme.checkerboardPatternDark})`,
-        color: '#fff'
+        background: `url(${theme.checkerboardPatternDark})`
       },
       plain: {
         background: 'transparent',
@@ -59,11 +53,11 @@ class Image extends React.Component {
       },
       plain_light: {
         background: theme.bgLight,
-        padding: `${theme.sizeL / 2}px`
+        padding: '20px'
       },
       plain_dark: {
         background: theme.bgDark,
-        padding: `${theme.sizeL / 2}px`
+        padding: '20px'
       }
     };
 
@@ -81,10 +75,20 @@ class Image extends React.Component {
 
     return (
         <div style={{...styles.container, ...backgroundStyle}}>
+          <Style
+            scopeSelector='.cg-ImageSpecimenDescription >'
+            rules={{
+              ':first-child': {
+                marginTop: 0
+              },
+              ':last-child': {
+                marginBottom: 0
+              }
+            }}/>
           <img style={styles.image} srcSet={src} src={fallbackSrc}/>
           {overlay && <img style={{...styles.overlay, ...(options.plain ? {top: 0, left: 0, maxWidth: '100%'} : null)}} srcSet={overlay} src={fallbackOverlay} />}
-          {title && <div style={styles.title}>{title}</div>}
-          {description && <div style={{...styles.description, ...(options.dark ? {color: '#fff'} : null)}}>{renderMarkdown({text: description})}</div>}
+          {title && <div style={{...styles.title, ...(options.dark ? {color: '#fff'} : null)}}>{title}</div>}
+          {description && <div className='cg-ImageSpecimenDescription' style={{...styles.description, ...(options.dark ? {color: '#fff'} : null)}}>{renderMarkdown({text: description})}</div>}
         </div>
     );
   }

--- a/src/specimens/Image.js
+++ b/src/specimens/Image.js
@@ -20,6 +20,7 @@ class Image extends React.Component {
         width: '100%'
       },
       image: {
+        display: 'block',
         maxWidth: '100%'
       },
       overlay: {

--- a/src/specimens/Image.js
+++ b/src/specimens/Image.js
@@ -12,12 +12,14 @@ class Image extends React.Component {
 
     const styles = {
       container: {
+        position: 'relative',
+        width: '100%'
+      },
+      imageContainer: {
         boxSizing: 'border-box',
         padding: '20px',
-        position: 'relative',
         background: `url(${theme.checkerboardPatternLight})`,
-        color: theme.textColor,
-        width: '100%'
+        color: theme.textColor
       },
       image: {
         display: 'block',
@@ -33,14 +35,16 @@ class Image extends React.Component {
           opacity: 1
         }
       },
+      meta: {
+        margin: `20px 0 0 0`
+      },
       title: {
         ...heading(theme, 0),
         fontWeight: 700,
-        margin: `20px 0 0 0`
+        margin: `0 0 8px 0`
       },
       description: {
-        ...text(theme, -1),
-        margin: `20px 0 0 0`
+        ...text(theme, -1)
       },
       light: {
         background: `url(${theme.checkerboardPatternLight})`
@@ -75,7 +79,8 @@ class Image extends React.Component {
     const fallbackOverlay = overlay ? overlay.split(' ')[0] : undefined;
 
     return (
-        <div style={{...styles.container, ...backgroundStyle}}>
+      <div style={styles.container}>
+        <div style={{...styles.imageContainer, ...backgroundStyle}}>
           <Style
             scopeSelector='.cg-ImageSpecimenDescription >'
             rules={{
@@ -88,9 +93,12 @@ class Image extends React.Component {
             }}/>
           <img style={styles.image} srcSet={src} src={fallbackSrc}/>
           {overlay && <img style={{...styles.overlay, ...(options.plain ? {top: 0, left: 0, maxWidth: '100%'} : null)}} srcSet={overlay} src={fallbackOverlay} />}
-          {title && <div style={{...styles.title, ...(options.dark ? {color: '#fff'} : null)}}>{title}</div>}
-          {description && <div className='cg-ImageSpecimenDescription' style={{...styles.description, ...(options.dark ? {color: '#fff'} : null)}}>{renderMarkdown({text: description})}</div>}
         </div>
+        {(title || description) && <div style={styles.meta}>
+          {title && <div style={styles.title}>{title}</div>}
+          {description && <div className='cg-ImageSpecimenDescription' style={styles.description}>{renderMarkdown({text: description})}</div>}
+        </div>}
+      </div>
     );
   }
 }

--- a/src/utils/renderMarkdown.js
+++ b/src/utils/renderMarkdown.js
@@ -2,7 +2,7 @@ import marked from './react-markdown';
 
 let MARKDOWN_CONFIG = {
   gfm: true,
-  breaks: false,
+  breaks: true,
   sanitize: false,
   smartLists: true,
   smartypants: true


### PR DESCRIPTION
Allow multiple lines in descriptions, style fixes, documentation updates.

Please review @TaniaBoa 😊 

<img width="421" alt="bildschirmfoto 2016-11-30 um 23 02 39" src="https://cloud.githubusercontent.com/assets/70969/20773237/2731dc5c-b751-11e6-9f20-1cb55d4fbf1a.png">

Fixes #255