### PR TITLE
Create router history object lazily

### DIFF
--- a/src/components/Catalog.js
+++ b/src/components/Catalog.js
@@ -6,8 +6,6 @@ import seqKey from '../utils/seqKey';
 
 import configureRoutes from '../configureRoutes';
 
-const hashHistory = useRouterHistory(createHashHistory)({queryKey: false});
-
 export default class Catalog extends Component {
   constructor() {
     super();
@@ -24,10 +22,12 @@ export default class Catalog extends Component {
   render() {
     const configuration = this.props;
     const {routerKey} = this.state;
+    const history = configuration.useBrowserHistory ?
+      browserHistory : useRouterHistory(createHashHistory)({queryKey: false});
     return (
       <Router
         key={routerKey}
-        history={configuration.useBrowserHistory ? browserHistory : hashHistory}
+        history={history}
         routes={configureRoutes(configuration)}
         render={applyRouterMiddleware(useScroll())}
       />


### PR DESCRIPTION
This allows catalog to be imported (required) in nodejs. It does not make
catalog usable in SSR, but at least node won't crash.