### PR TITLE
Responsive mode layout fix

### DIFF
--- a/src/components/App/AppLayout.js
+++ b/src/components/App/AppLayout.js
@@ -91,7 +91,7 @@ const getStyles = (theme, sidebarVisible) => ({
     flexDirection: 'column',
     position: 'relative',
     '@media (min-width: 1000px)': {
-      marginLeft: SIDEBAR_WIDTH
+      paddingLeft: SIDEBAR_WIDTH
     }
   }
 });

--- a/src/components/Frame/Frame.js
+++ b/src/components/Frame/Frame.js
@@ -2,6 +2,15 @@ import React, {Component, PropTypes} from 'react';
 import {catalogShape} from '../../CatalogPropTypes';
 import FrameComponent from './FrameComponent';
 
+const frameStyle = {
+  width: '100%',
+  height: '100%',
+  lineHeight: 0,
+  margin: 0,
+  padding: 0,
+  border: 'none'
+};
+
 const renderStyles = (styles) => {
   return styles.map((src, i) => <link key={i} href={src} rel='stylesheet' type='text/css' />);
 };
@@ -17,41 +26,37 @@ export default class Frame extends Component {
     const {catalog: {page: {styles}}} = this.context;
     const height = this.state.height || this.props.height;
     const autoHeight = !this.props.height;
-
-    const scaledHeight = this.props.height && width >= parentWidth ? height * (parentWidth / width) : 'auto';
-
-    const style = {
-      width: width || '100%',
-      lineHeight: 0,
-      margin: 0,
-      padding: 0,
-      border: 'none',
-      transformOrigin: '0% 0%',
-      height: height,
-      overflow: 'hidden',
-      transform: `scale( ${width <=  parentWidth ? 1 : parentWidth / width} )`
-    };
+    const scale = Math.min(1, parentWidth / width);
+    const scaledHeight = autoHeight ? height : height * scale;
 
     return (
       <div style={{lineHeight: 0, width: parentWidth, height: scaledHeight}}>
-        <FrameComponent
-          style={style}
-          frameBorder='0'
-          allowTransparency='true'
-          scrolling='no'
-          head={[
-            <style key='stylereset'>{'html,body{margin:0;padding:0}'}</style>,
-            ...renderStyles(styles)
-          ]}
-          onRender={autoHeight ? (content) => {
-            const contentHeight = content.offsetHeight;
-            if (contentHeight !== height) {
-              this.setState({height: contentHeight});
-            }
-          } : ()=>null}
-        >
-          {children}
-        </FrameComponent>
+        <div style={{
+          width: width,
+          height: height,
+          transformOrigin: '0% 0%',
+          transform: `scale( ${scale} )`,
+          overflow: 'hidden'
+        }}>
+          <FrameComponent
+            style={frameStyle}
+            frameBorder='0'
+            allowTransparency='true'
+            scrolling='no'
+            head={[
+              <style key='stylereset'>{'html,body{margin:0;padding:0}'}</style>,
+              ...renderStyles(styles)
+            ]}
+            onRender={autoHeight ? (content) => {
+              const contentHeight = content.offsetHeight;
+              if (contentHeight !== height) {
+                this.setState({height: contentHeight});
+              }
+            } : ()=>null}
+          >
+            {children}
+          </FrameComponent>
+        </div>
       </div>
     );
   }

--- a/src/specimens/Html.js
+++ b/src/specimens/Html.js
@@ -99,7 +99,7 @@ class Html extends React.Component {
 
   componentDidMount() {
     const {runScript} = this.props;
-    runScript && Array.from(this.refs.specimen.querySelectorAll('script')).forEach(runscript);
+    runScript && Array.from(this.specimen.querySelectorAll('script')).forEach(runscript);
 
     if (this.state.activeScreenSize) {
       window.addEventListener('resize', this.updateParentWidth);
@@ -122,7 +122,7 @@ class Html extends React.Component {
   }
 
   updateParentWidth() {
-    const nextParentWidth = this.refs.specimen.getBoundingClientRect().width - 30;
+    const nextParentWidth = this.specimen.getBoundingClientRect().width - 30;
     if (nextParentWidth !== this.state.parentWidth) {
       this.setState({parentWidth: nextParentWidth});
     }
@@ -167,19 +167,21 @@ class Html extends React.Component {
     }
 
     return (
-      <div ref='specimen' style={styles.container} className='cg-Specimen-Html'>
+      <div style={styles.container} className='cg-Specimen-Html' ref={el => {this.specimen = el;}}>
         {toggle}
-        {activeScreenSize &&
+        {parentWidth && activeScreenSize &&
           <ResponsiveTabs theme={theme} sizes={validSizes} action={this.setSize} activeSize={activeScreenSize} parentWidth={parentWidth}/>
         }
-        <div style={{...styles.content, ...exampleStyles}}>
-          {frame || activeScreenSize
-            ? <Frame width={activeScreenSize && activeScreenSize.width} parentWidth={parentWidth ? parentWidth : '100%'} height={activeScreenSize && activeScreenSize.height}>
-                {content}
-              </Frame>
-            : content
-          }
-        </div>
+        {parentWidth &&
+          <div style={{...styles.content, ...exampleStyles}}>
+            {frame || activeScreenSize
+              ? <Frame width={activeScreenSize && activeScreenSize.width} parentWidth={parentWidth ? parentWidth : '100%'} height={activeScreenSize && activeScreenSize.height}>
+                  {content}
+                </Frame>
+              : content
+            }
+          </div>
+        }
         {source}
       </div>
     );

--- a/src/specimens/ReactSpecimen/ReactSpecimen.js
+++ b/src/specimens/ReactSpecimen/ReactSpecimen.js
@@ -93,7 +93,7 @@ class ReactSpecimen extends Component {
   }
 
   updateParentWidth() {
-    const nextParentWidth = this.refs.specimen.getBoundingClientRect().width - 30;
+    const nextParentWidth = this.specimen.getBoundingClientRect().width - 30;
     if (nextParentWidth !== this.state.parentWidth) {
       this.setState({parentWidth: nextParentWidth});
     }
@@ -146,17 +146,19 @@ class ReactSpecimen extends Component {
     if (error) return error;
 
     return (
-      <section style={styles.container} ref='specimen'>
-        {activeScreenSize &&
+      <section style={styles.container} ref={el => {this.specimen = el;}}>
+        {parentWidth && activeScreenSize &&
           <ResponsiveTabs theme={theme} sizes={validSizes} action={this.setSize} activeSize={activeScreenSize} parentWidth={parentWidth}/>
         }
-        <div style={{...styles.content, ...exampleStyles}}>
-          {frame || activeScreenSize
-            ? <Frame width={activeScreenSize && activeScreenSize.width} parentWidth={parentWidth ? parentWidth : '100%'} height={activeScreenSize && activeScreenSize.height}>
-                {element}
-              </Frame>
-            : element }
-        </div>
+        {parentWidth &&
+          <div style={{...styles.content, ...exampleStyles}}>
+            {frame || activeScreenSize
+              ? <Frame width={activeScreenSize && activeScreenSize.width} parentWidth={parentWidth ? parentWidth : '100%'} height={activeScreenSize && activeScreenSize.height}>
+                  {element}
+                </Frame>
+              : element }
+          </div>
+        }
         {!noSource && <HighlightedCode language='jsx' code={code} theme={theme} />}
       </section>
     );


### PR DESCRIPTION
In some edge cases, the iframe got scaled twice (e.g. one `transform: scale(0.5)` somehow got applied twice, resulting in an iframe with scale 0.25). Wrapping it in an element with the scale transform *and* defined width and height solved this issue.

To prevent a rendering glitch, the React and HTML specimens now only show the frame after their own width is measured.