### PR TITLE
Fix path configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,6 @@
         //   {path: 'advanced/extending', title: 'Writing Specimens', src: 'docs/coming-soon.md'},
         // ]},
         {
-          path: 'specimens-group',
           title: 'Specimens',
           pages: [
             {

--- a/src/__snapshots__/configure.test.js.snap
+++ b/src/__snapshots__/configure.test.js.snap
@@ -184,7 +184,7 @@ Object {
           "title": "Bar",
         },
       ],
-      "path": "/",
+      "path": null,
       "scripts": Array [],
       "styles": Array [],
       "superTitle": "Catalog",

--- a/src/configure.js
+++ b/src/configure.js
@@ -66,7 +66,7 @@ export default (config) => {
         ...page,
         id: ++pageId,
         // Currently, catalog can't be nested inside other page routes, it messes up <Link> matching. Use `basePath`
-        path: parsePath(page.path || page.name, {basePath}).pathname,
+        path: page.pages ? null : parsePath(page.path || page.name, {basePath}).pathname,
         pages: page.pages ? page.pages.reduce(pageReducer, []).map((p) => ({...p, superTitle: page.title})) : null,
         styles: Array.from(new Set([...configStyles, ...pageStyles])),
         scripts: Array.from(new Set([...configScripts, ...pageScripts])),

--- a/src/configure.test.js
+++ b/src/configure.test.js
@@ -18,7 +18,6 @@ test('Configuration with nested pages', () => {
     title: 'Catalog',
     pages: [
       {
-        path: '/',
         title: 'Overview',
         pages: [
           {


### PR DESCRIPTION
For page groups, the `path` property is unnecessary but Catalog would fail when not provided (regression in 2.5.0).

Fixes #265