### PR TITLE
Be more open what to accept as page content

### DIFF
--- a/docs/basics/configuration.md
+++ b/docs/basics/configuration.md
@@ -51,7 +51,8 @@ Catalog pages need at least three properties:
 
 - `path : String`: The path where the page is accessible
 - `title : String`: The title of the page (also shows up in the navigation)
-- `content : Function`: Function which returns the content of the page.
+- `content : Mixed`: The content of the page. Catalog supports multiple ways to define
+   what should be shown. See explanation below.
 
 Catalog also supports `src` and `component` as a different way to specify
 the page content. These properties are deprecated and support will be removed
@@ -72,12 +73,58 @@ lang: js
     {
       path: '/',
       title: 'Introduction',
-      content: () => Catalog.fetchMarkdown('intro.md')
+      content: require('intro.md')
     },
     // Other pages …
   ]
 }
 ```
+
+##### Content
+
+You can define the content using one of the following ways:
+
+###### I. Component
+
+Can even be imported from another module. You can use `require()` or the `import` syntax
+if you have the corresponding webpack loader configured.
+
+```code
+lang: js
+---
+import Image from './components/Image/Image.js'
+
+{
+  title: 'Hint',
+  content: require('./components/Hint/Hint.js')
+},
+{
+  title: 'Image',
+  content: Image
+}
+```
+
+###### II. Function which returns a promise
+
+This can be used to enable [code-splitting](https://webpack.github.io/docs/code-splitting.html). If you use Webpack, then use `require.ensure()` or the `import` function.
+
+```code
+lang: js
+---
+{
+  title: 'Hint',
+  content: () => import('./components/Hint/Hint.js')`
+},
+{
+  title: 'Image',
+  content: () => new Promise((resolve) => {
+    require.ensure([], () => {
+      resolve(require('./components/Image/Image.js'))
+    })
+  })
+}
+```
+
 
 ### Page Groups
 
@@ -99,7 +146,7 @@ Page groups can only contain pages but not other page groups.
     {
       path: '/',
       title: 'Introduction',
-      src: 'intro.md'
+      content: require('intro.md')
     },
     {
       title: 'Basics',
@@ -107,7 +154,7 @@ Page groups can only contain pages but not other page groups.
         {
           path: '/get-started',
           title: 'Get Started',
-          src: 'get-started.md'
+          content: require('get-started.md')
         },
         // Other subpages of 'Basics'
       ]
@@ -265,7 +312,9 @@ To test or document responsive behavior of [React](/specimens/react#responsive-d
 Let's assume you want to work with a smart watch, a tablet and Desktop, the Catalog configuration could look like this:
 
 ```code
-...
+lang: js
+---
+…
 title: 'Catalog',
 responsiveSizes: [
   {name: 'watch', width: 272, height: 340}
@@ -273,8 +322,7 @@ responsiveSizes: [
   {name: 'desktop', width: 1920, height: 1080},
 ],
 pages : [
-...
-
+…
 ```
 
 
@@ -289,6 +337,8 @@ Path to a logo image file which will be placed in the top-left corner.
 Object which describes which colors, fonts and font sizes to use.
 
 ```code
+lang: js
+---
 …
 title: 'Catalog',
 theme: {
@@ -341,6 +391,8 @@ Background colors and patterns for html, react, and image specimens.
 Map from [PrismJS](http://prismjs.com/) token type to style object. Example:
 
 ```code
+lang: js
+---
 codeStyles: {
   tag: {color: '#FF5555', fontWeight: 'bold'}
 }

--- a/src/configureRoutes.js
+++ b/src/configureRoutes.js
@@ -5,12 +5,96 @@ import warning from './utils/warning';
 import requireModuleDefault from './utils/requireModuleDefault';
 import CatalogContext from './components/CatalogContext';
 import PageContent from './components/Page/PageContent';
-import fetchMarkdown from './fetchMarkdown';
+import Page from './components/Page/Page';
+import fetchMarkdown, {fetchMarkdownNoCatch} from './fetchMarkdown';
+
+// Use heuristic to detect of the value is a valid react component
+// (a value which can be given as the first argument to React.createElement()).
+//
+// It works like this: if it's a constructor and the instance has a 'render'
+// function it's good. That handles both ES6 classes and components created
+// with createClass(). And because we're not using instanceof checks, we're
+// independent of the React library which the user is using (might be
+// different from the one used by Catalog itself).
+const isReactComponent = (X) => {
+  try {
+    const v = new X();
+    return v !== null && typeof v === 'object' && typeof v.render === 'function';
+  } catch (e) {
+    return false;
+  }
+};
 
 const pageComponent = (page) => {
+  // page.content can be almost anything (as long as it's truthy) and
+  // we'll do our best to render it.
   if (page.content) {
-    return (props) => <PageContent {...props} contentPromiseFn={() => Promise.resolve(page.content())} />;
+    const content = page.content;
+
+    const gaveUpPage = () =>
+      <Page>{`\`\`\`hint|warning\n# Catalog: I gave up.\n\n I don't know how to handle this page content: "${content}"\n\`\`\``}</Page>;
+
+    return (props) => {
+      // This function takes anything and returns a Promise which resolves
+      // to a React$Element. It's magic.
+      const coerce = (x) => {
+        // 1. React$Element
+        // This is the termination condition of this recursive function.
+        if (React.isValidElement(x)) {
+          return Promise.resolve(x);
+        }
+
+        // 2. React Component
+        // And this is the second termination condition.
+        if (isReactComponent(x)) {
+          return Promise.resolve(React.createElement(x));
+        }
+
+        // 3. Promise
+        if (typeof x.then === 'function') {
+          return x.then(coerce).catch(e => <Page>{`\`\`\`hint|warning\nPromise failed.\n${e}\n\`\`\``}</Page>);
+        }
+
+        // 4. Function
+        // Invoke the function and coerce its return value.
+        if (typeof x === 'function') {
+          return coerce(x());
+        }
+
+        // 5. String
+        // Gets complicated, but whatever. Can be either an URL to a markdown file, or the
+        // markdown source itself. But wait, could also be an URL to a JS module (which we
+        // can import(), in ESnext, so we ignore that case for now).
+        //
+        // To handle all cases, we resolve the string in all the possible ways we can think
+        // of and then try to guess which one the user meant.
+        if (typeof x === 'string') {
+          return Promise.all([
+            fetchMarkdownNoCatch(x).catch(() => undefined),
+            Promise.resolve(<Page>{x}</Page>)
+          ]).then(results => {
+            const firstGoodResult = results.find(r => r !== undefined);
+            return firstGoodResult !== undefined ? firstGoodResult : gaveUpPage();
+          });
+        }
+
+        // 6. Other (number, boolean, object, array, regexp, …)
+        return Promise.resolve(gaveUpPage());
+      };
+
+      const contentPromiseFn = () => {
+        try {
+          return coerce(content);
+        } catch (e) {
+          return Promise.resolve(gaveUpPage());
+        }
+      };
+
+      return <PageContent {...props} contentPromiseFn={contentPromiseFn} />;
+    };
   }
+
+  // Legacy
   if (page.src) {
     return (props) => <PageContent {...props} contentPromiseFn={() => fetchMarkdown(page.src)} />;
   }

--- a/src/configureRoutes.js
+++ b/src/configureRoutes.js
@@ -78,7 +78,12 @@ const pageComponent = (page) => {
           });
         }
 
-        // 6. Other (number, boolean, object, array, regexp, …)
+        // 6. Default export from a module
+        if (typeof x.default !== 'undefined') {
+          return coerce(x.default);
+        }
+
+        // 7. Other (number, boolean, object, array, regexp, …)
         return Promise.resolve(gaveUpPage());
       };
 

--- a/src/fetchMarkdown.js
+++ b/src/fetchMarkdown.js
@@ -1,13 +1,28 @@
 import React from 'react';
 import Page from './components/Page/Page';
 
-export default (url) =>
+const markdownContentTypes = [
+  'text/plain',
+  'text/x-markdown'
+];
+
+const isMarkdownContentType = (h) =>
+  markdownContentTypes.some(ct => h.includes(ct));
+
+const isMarkdownResponse = (res) =>
+  (res.status >= 200 && res.status < 300) &&
+  (!res.headers.has('content-type') || isMarkdownContentType(res.headers.get('content-type')));
+
+// Like 'fetchMarkdown' but doesn't catch errors in the promise.
+export const fetchMarkdownNoCatch = (url) =>
   fetch(url, {credentials: 'same-origin'})
     .then(res => {
-      if (res.status >= 200 && res.status < 300) {
+      if (isMarkdownResponse(res)) {
         return res.text();
       }
       throw new Error(`Unexpected status code: ${res.status}`);
-    })
-    .then(text => <Page>{text}</Page>)
-    .catch(error => <Page>{`Catalog.Content.fetchMarkdown: ${error}`}</Page>);
+    }).then(text => <Page>{text}</Page>);
+
+export default (url) =>
+  fetchMarkdownNoCatch(url)
+    .catch(error => <Page>{`Catalog.fetchMarkdown: ${error}`}</Page>);


### PR DESCRIPTION
Now we can support all possible forms of `content`: strings, functions, promises, react components or elements. Strings can be both URLs and inline markdown, automagically handled. And promises can return strings which can be URLs to markdown files. Even cases of complete rubbish configuration (eg. `content: true`) are handled reasonably well.