### PR TITLE
Improve tagged template literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Create a new stacking context for the whole <Page> component [#223](https://github.com/interactivethings/catalog/issues/223)
 - Don't re-render page when menu is toggled [#271](https://github.com/interactivethings/catalog/issues/271)
 - New option on the image specimen: `scale`. See [#76](https://github.com/interactivethings/catalog/issues/76)
-- Provide a function (`Catalog.markdownPage`) which converts a template literal into a Page component [#277](https://github.com/interactivethings/catalog/pull/277)
+- Provide a function (`Catalog.markdown`) which converts a template literal into a Page component [#277](https://github.com/interactivethings/catalog/pull/277), [#281](https://github.com/interactivethings/catalog/pull/281)
 - Bugfixes:
   - When clicking a title anchor, page scrolls to top instead of to the anchor [#275](https://github.com/interactivethings/catalog/issues/275)
 

--- a/docs/basics/configuration.md
+++ b/docs/basics/configuration.md
@@ -141,14 +141,14 @@ lang: js
 }
 ```
 
-##### `markdownPage`
+##### `markdown`
 
-To make it easier to write the bulk of the documentation with Markdown but intersperse with your own React components, you can use the `Catalog.markdownPage` function.
+To make it easier to write the bulk of the documentation with Markdown but intersperse with your own React components, you can use the `Catalog.markdown` function.
 
 ```code
 lang: js
 ---
-export default Catalog.markdownPage`
+export default Catalog.markdown`
 # This is a heading
 
 ${<MyComponent />}

--- a/docs/react-integration.md
+++ b/docs/react-integration.md
@@ -42,6 +42,72 @@ ReactDOM.render(
 );
 ```
 
+## Write Documentation with React Components
+
+Instead of using Markdown files, you can use Catalog's `Page` and all specimen components directly to create your own page components. This enables you for example to
+
+- generate documentation programmatically,
+- mix specimens with other components,
+- or share state across specimens.
+
+```hint|directive
+As with the webpack loader transformed Markdown files, use `component` instead of `src` in the page configuration.
+```
+
+```code|lang-jsx
+import React from 'react';
+import {Page, ReactSpecimen, ColorPaletteSpecimen} from 'catalog';
+import Button from 'components/Button/Button';
+
+export default () => (
+  <Page>
+    <h2>My Buttons</h2>
+
+    <p>Are so nice</p>
+
+    <ul>
+      <li>Yes</li>
+      <li>or no?</li>
+    </ul>
+
+    <ReactSpecimen span={3}>
+      {'<Button primary>Foo</Button>'}
+    </ReactSpecimen>
+
+    <ColorPaletteSpecimen span={3} colors={generateColorPalette()} />
+  </Page>
+);
+```
+
+To make it easier to write the bulk of the documentation with Markdown but intersperse with your own React components, you can use the `markdown` [tagged template literal](http://exploringjs.com/es6/ch_template-literals.html).
+
+```code
+lang: js
+---
+import React from 'react';
+import {markdown, ReactSpecimen, ColorPaletteSpecimen} from 'catalog';
+import Button from 'components/Button/Button';
+
+export default markdown`
+## My Buttons
+
+Are so nice
+
+- Yes
+- or no?
+
+${
+  <ReactSpecimen span={3}>
+    {'<Button primary>Foo</Button>'}
+  </ReactSpecimen>
+}
+
+${
+  <ColorPaletteSpecimen span={3} colors={generateColorPalette()} />
+}
+`
+```
+
 ## Hot Reloadable Markdown Files
 
 Catalog provides a [webpack](http://webpack.github.io/) loader which allows you to import hot-reloadable Markdown files.
@@ -88,7 +154,7 @@ To save you from prepending `catalog/lib/loader!raw!` to each import, you can al
 
 ## Advanced Integration
 
-> If you need more control over the integration into your application, Catalog is flexible enough to supports some advanced use cases.
+> If you need more control over the integration into your application, Catalog is flexible enough to supports advanced use cases.
 
 ### React Router Routes
 
@@ -122,41 +188,4 @@ ReactDOM.render(
 );
 ```
 
-### Write Documentation with React Components
 
-Instead of using Markdown files, you can use Catalog's `Page` and all specimen components directly to create your own page components. This enables you for example to
-
-- generate documentation programmatically,
-- mix specimens with other components,
-- or share state across specimens.
-
-```hint|directive
-As with the webpack loader transformed Markdown files, use `component` instead of `src` in the page configuration.
-```
-
-```code|lang-jsx
-import React from 'react';
-import {Page, ReactSpecimen, ColorPaletteSpecimen} from 'catalog';
-import Button from 'components/Button/Button';
-
-export default () => (
-  <Page>
-    <h2>My Buttons</h2>
-
-    <p>Are so nice</p>
-
-    <ul>
-      <li>Yes</li>
-      <li>or no?</li>
-    </ul>
-
-    <hr />
-
-    <ReactSpecimen span={3}>
-      {'<Button primary>Foo</Button>'}
-    </ReactSpecimen>
-
-    <ColorPaletteSpecimen span={3} colors={generateColorPalette()}>
-  </Page>
-);
-```

--- a/src/index-standalone.js
+++ b/src/index-standalone.js
@@ -6,7 +6,7 @@ export {default as render} from './render';
 export {default as configure} from './configure';
 export {default as configureRoutes} from './configureRoutes';
 export {configureJSXRoutes as configureJSXRoutes} from './configureRoutes';
-export {default as markdownPage} from './markdownPage';
+export {default as markdown} from './markdownPage';
 
 // Components
 export {default as Catalog} from './components/Catalog';

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ export {default as render} from './render';
 export {default as configure} from './configure';
 export {default as configureRoutes} from './configureRoutes';
 export {configureJSXRoutes as configureJSXRoutes} from './configureRoutes';
-export {default as markdownPage} from './markdownPage';
+export {default as markdown} from './markdownPage';
 
 // Components
 export {default as Catalog} from './components/Catalog';

--- a/src/markdownPage.js
+++ b/src/markdownPage.js
@@ -26,7 +26,7 @@ import Page from './components/Page/Page';
 // > ${<MyComponent isCustomComponent={'AWESOME'} />}
 // > `;
 
-const markdownPage = (strings, ...values) =>
+const markdownPage = (strings, ...values) => () =>
   createElement(Page, {},
     ...values.reduce((a, v, i) => a.concat([v, strings[i + 1]]), [strings[0]]));
 

--- a/src/markdownPage.test.js
+++ b/src/markdownPage.test.js
@@ -16,5 +16,5 @@ Cool, eh?`}
 </Hint>
 }
 `;
-  expect(page).toMatchSnapshot();
+  expect(page()).toMatchSnapshot();
 });


### PR DESCRIPTION
I've made two small changes to the tagged template literal:

- Renamed it to `Catalog.markdown` (`markdown` when imported), mostly because I want editors to treat the string content as markdown and apply the correct syntax highlighting. Currently no editor supports this but I'd like to be future-proof 😄 
- `` markdown`# Foo` `` now returns a function (component) which is more what I'd expect it to do.

So the changed template literal works like this:

```js
import {markdown} from 'catalog'

const MyPage = markdown`
# Hello

This is a paragraph.

- one
- two
`
```

I've also updated the docs and moved it from the Configuration to the React Integration page.