### PR TITLE
Responsive specimen inifinite growth

### DIFF
--- a/src/specimens/Html.js
+++ b/src/specimens/Html.js
@@ -20,6 +20,7 @@ function getStyle(theme) {
       boxSizing: 'border-box',
       position: 'relative',
       flexBasis: '100%',
+      width: '100%',
       marginTop: '40px',
       fontFamily: theme.fontFamily
     },


### PR DESCRIPTION
The underlying issue was an off-by-2 error when calculating the `parentWidth` (not accounting for the 1px border on both sides). Each resize event would grow the width by 2px.

I also changed `<Frame />` to not affect the width of the parent element. This is needed to allow the frame to shrink when the user resizes the window down. Without that change, the frame can only grow but never shrink.