### PR TITLE
Improve markdown template literal

### DIFF
--- a/src/__snapshots__/markdownPage.test.js.snap
+++ b/src/__snapshots__/markdownPage.test.js.snap
@@ -17,3 +17,17 @@ exports[`Catalog markdown page template literal 1`] = `
   
 </Page>
 `;
+
+exports[`Catalog markdown page template literal with arbitrary values 1`] = `
+<Page>
+  
+  # This is a title
+  
+  A paragraph 123
+  
+  ~~~
+  [{"a":"some"},{"a":"data"}]
+  ~~~
+  
+</Page>
+`;

--- a/src/markdownPage.test.js
+++ b/src/markdownPage.test.js
@@ -18,3 +18,16 @@ Cool, eh?`}
 `;
   expect(page()).toMatchSnapshot();
 });
+
+test('Catalog markdown page template literal with arbitrary values', () => {
+  const page = markdownPage`
+# This is a title
+
+A paragraph ${123}
+
+~~~
+${[{a: 'some'}, {a: 'data'}]}
+~~~
+`;
+  expect(page()).toMatchSnapshot();
+});


### PR DESCRIPTION
In addition to valid React elements, allow strings, numbers and JSON-stringifiable objects. This enables passing in arbitrary data to specimens and Markdown text (e.g. a variable with data).