### PR TITLE
Add CLI support for config file

### DIFF
--- a/cli/src/actions/loadConfigFile.js
+++ b/cli/src/actions/loadConfigFile.js
@@ -1,0 +1,13 @@
+// @flow
+import {resolveAppPath} from '../utils/paths';
+import {exists} from 'sander';
+
+type ConfigFile = {
+  webpack?: Function
+} | null;
+
+export default async (): Promise<ConfigFile> => {
+  const configFilePath = resolveAppPath('catalog.config.js');
+  const configFileExists = await exists(configFilePath);
+  return configFileExists ? require(configFilePath) : null;
+};

--- a/cli/src/actions/runDevServer.js
+++ b/cli/src/actions/runDevServer.js
@@ -31,7 +31,7 @@ export default async (config: Object, host: string, port: number, https: boolean
       '**': proxy
     }} : {}),
     overlay: false,
-    setup(app) {
+    before(app) {
       // Next.js serves static files from /static – which can't be configured with `contentBase` directly
       if (framework === 'NEXT') {
         app.use('/static', express.static(paths.appStaticSrcDir));

--- a/cli/src/config/createReactApp.js
+++ b/cli/src/config/createReactApp.js
@@ -34,7 +34,8 @@ export default (paths: Object, useBabelrc: boolean, dev: boolean) => ({
         // Process JS with Babel.
         {
           test: /\.(js|jsx)$/,
-          include: [paths.appSrc, paths.catalogSrcDir],
+          include: [paths.appRoot, paths.catalogSrcDir],
+          exclude: /node_modules/,
           loader: require.resolve('babel-loader'),
           options: {
             babelrc: useBabelrc,


### PR DESCRIPTION
Currently supports only the `webpack` option which must be a function that accepts the generated config and must return the modified one. We can add more config options later (merging with defaults and/or CLI options is a bit more complicated and should be properly tested).

Additionally, I've modified the default webpack (CRA-like) config, so that JS files are not only transpiled in `src` but the app root (excluding `node_modules`) to make it easier to integrate with non-CRA setups.

👉  @bebraw @oyeanuj @wereHamster