### PR TITLE
Enable iframe scrolling in responsive mode

### DIFF
--- a/src/components/Frame/Frame.js
+++ b/src/components/Frame/Frame.js
@@ -23,7 +23,7 @@ export default class Frame extends Component {
   }
 
   render() {
-    const {children, width, parentWidth} = this.props;
+    const {children, width, parentWidth, scrolling} = this.props;
     const {catalog: {page: {styles}}} = this.context;
     const height = this.state.height || this.props.height;
     const autoHeight = !this.props.height;
@@ -43,9 +43,9 @@ export default class Frame extends Component {
             style={frameStyle}
             frameBorder='0'
             allowTransparency='true'
-            scrolling='no'
+            scrolling={scrolling}
             head={[
-              <style key='stylereset'>{'html,body{margin:0;padding:0}'}</style>,
+              <style key='stylereset'>{'html,body{margin:0;padding:0;}'}</style>,
               ...renderStyles(styles)
             ]}
             onRender={autoHeight ? (content) => {
@@ -67,7 +67,8 @@ Frame.propTypes = {
   children: PropTypes.element,
   width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   parentWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  height: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+  height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  scrolling: PropTypes.oneOf(['yes', 'no', 'auto'])
 };
 
 Frame.contextTypes = {

--- a/src/specimens/Html.js
+++ b/src/specimens/Html.js
@@ -179,7 +179,7 @@ class Html extends React.Component {
         {(!options.responsive || parentWidth) &&
           <div style={{...styles.content, ...exampleStyles}}>
             {frame || activeScreenSize
-              ? <Frame width={activeScreenSize && activeScreenSize.width} parentWidth={parentWidth ? parentWidth : '100%'} height={activeScreenSize && activeScreenSize.height}>
+              ? <Frame width={activeScreenSize && activeScreenSize.width} parentWidth={parentWidth ? parentWidth : '100%'} height={activeScreenSize && activeScreenSize.height} scrolling={frame ? 'no' : undefined}>
                   {content}
                 </Frame>
               : content

--- a/src/specimens/ReactSpecimen/ReactSpecimen.js
+++ b/src/specimens/ReactSpecimen/ReactSpecimen.js
@@ -159,7 +159,7 @@ class ReactSpecimen extends Component {
         {(!options.responsive || parentWidth) &&
           <div style={{...styles.content, ...exampleStyles}}>
             {frame || activeScreenSize
-              ? <Frame width={activeScreenSize && activeScreenSize.width} parentWidth={parentWidth ? parentWidth : '100%'} height={activeScreenSize && activeScreenSize.height}>
+              ? <Frame width={activeScreenSize && activeScreenSize.width} parentWidth={parentWidth ? parentWidth : '100%'} height={activeScreenSize && activeScreenSize.height} scrolling={frame ? 'no' : undefined}>
                   {element}
                 </Frame>
               : element }


### PR DESCRIPTION
This should match the user's mental model more closely to what happens in responsive mode (which is supposed to emulate a device). Whereas in framed mode, the intention is just to isolate an element from the parent page, and the specimen is automatically resized anyway.

Fixes #320 