### PR TITLE
Make nested pages able to be hidden from menu also

### DIFF
--- a/src/components/Menu/NestedList.js
+++ b/src/components/Menu/NestedList.js
@@ -28,7 +28,7 @@ const NestedList = ({theme, pages, title}, {router}) => {
       </Link>
       { !collapsed &&
         <ul style={{...currentStyle.list, ...currentStyle.listNested, padding: 0}}>
-          { pages.map(page => <ListItem key={page.id} page={page} nested theme={theme} />) }
+          { pages.filter((page) => !page.hideFromMenu).map(page => <ListItem key={page.id} page={page} nested theme={theme} />) }
         </ul>
       }
     </div>


### PR DESCRIPTION
Currently `hideFromMenu` only works for top level pages and page groups. The flag is ignored on nested pages. This should make it respect the flag on any page.