### PR TITLE
Allow custom PostCSS config

### DIFF
--- a/cli/src/actions/loadPaths.js
+++ b/cli/src/actions/loadPaths.js
@@ -22,6 +22,7 @@ export default async (catalogSrcDir: string, catalogBuildDir: string, framework:
   appSrc: resolveAppPath('src'),
   yarnLockFile: resolveAppPath('yarn.lock'),
   babelrc: resolveAppPath('.babelrc'),
+  postCSSConfig: resolveAppPath('.postcssrc') || resolveAppPath('postcss.config.js') || resolveAppPath('.postcssrc.js'),
   appNodeModules: resolveAppPath('node_modules'),
   ownNodeModules: resolveOwnPath('..', '..', 'node_modules'),
   nodePaths: nodePaths,

--- a/cli/src/config/createReactApp.js
+++ b/cli/src/config/createReactApp.js
@@ -60,7 +60,7 @@ export default (paths: Object, useBabelrc: boolean, dev: boolean) => ({
                 }
               }, {
                 loader: require.resolve('postcss-loader'),
-                options: {
+                options: paths.postCSSConfig ? {} : {
                   ident: 'postcss', // https://webpack.js.org/guides/migrating/#complex-options
                   plugins: () => {
                     return [
@@ -90,7 +90,7 @@ export default (paths: Object, useBabelrc: boolean, dev: boolean) => ({
                 }
               }, {
                 loader: require.resolve('postcss-loader'),
-                options: {
+                options: paths.postCSSConfig ? {} : {
                   ident: 'postcss', // https://webpack.js.org/guides/migrating/#complex-options
                   plugins: () => {
                     return [


### PR DESCRIPTION
Following my question in #327, I thought I'd try to contribute a potential solution.

This change allows catalog to detect custom postcss config files in a project and skips configuring postcss-loader (at least under the createReactApp scheme) if one is present.