### PR TITLE
Make Type specimen accept arrays for values to customize labels

### DIFF
--- a/src/specimens/Type.js
+++ b/src/specimens/Type.js
@@ -84,8 +84,8 @@ class Type extends React.Component {
 
     const headings = options.headings
       ? options.headings.map( (heading, i) => {
-        const headingValue = typeof heading === 'object' ? heading.value : heading;
-        const headingLabel = typeof heading === 'object' ? heading.label : 'h' + (i + 1);
+        const headingValue = (heading !== null && typeof heading === 'object') ? heading.value : heading;
+        const headingLabel = (heading !== null && typeof heading === 'object') ? heading.label : 'h' + (i + 1);
         const isPixel = typeof headingValue === 'number' ? 'px' : '';
         return (
           <div key={i}>
@@ -98,8 +98,8 @@ class Type extends React.Component {
 
     const paragraphs = options.paragraphs
       ? options.paragraphs.map( (paragraph, i) => {
-        const paragraphValue = typeof paragraph === 'object' ? paragraph.value : paragraph;
-        const paragraphLabel = typeof paragraph === 'object' ? paragraph.label : 'Paragraph';
+        const paragraphValue = (paragraph !== null && typeof heading === 'object') ? paragraph.value : paragraph;
+        const paragraphLabel = (paragraph !== null && typeof heading === 'object') ? paragraph.label : 'Paragraph';
 
         const values = paragraphValue.split('/').map((item) => {
           return /[a-z]/i.test(item) ? `${item}` : `${item}px`;

--- a/src/specimens/Type.js
+++ b/src/specimens/Type.js
@@ -143,8 +143,8 @@ Type.propTypes = {
   weight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   tracking: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   image: PropTypes.string,
-  headings: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.object])),
-  paragraphs: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.object])),
+  headings: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.shape({label:PropTypes.string,value:PropTypes.oneOfType([PropTypes.string, PropTypes.number])})])),
+  paragraphs: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.shape({label:PropTypes.string,value:PropTypes.oneOfType([PropTypes.string, PropTypes.number])})])),
   catalog: catalogShape.isRequired
 };
 

--- a/src/specimens/Type.js
+++ b/src/specimens/Type.js
@@ -98,8 +98,8 @@ class Type extends React.Component {
 
     const paragraphs = options.paragraphs
       ? options.paragraphs.map( (paragraph, i) => {
-        const paragraphValue = (paragraph !== null && typeof heading === 'object') ? paragraph.value : paragraph;
-        const paragraphLabel = (paragraph !== null && typeof heading === 'object') ? paragraph.label : 'Paragraph';
+        const paragraphValue = (paragraph !== null && typeof paragraph === 'object') ? paragraph.value : paragraph;
+        const paragraphLabel = (paragraph !== null && typeof paragraph === 'object') ? paragraph.label : 'Paragraph';
 
         const values = paragraphValue.split('/').map((item) => {
           return /[a-z]/i.test(item) ? `${item}` : `${item}px`;

--- a/src/specimens/Type.js
+++ b/src/specimens/Type.js
@@ -143,8 +143,8 @@ Type.propTypes = {
   weight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   tracking: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   image: PropTypes.string,
-  headings: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.shape])),
-  paragraphs: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.shape])),
+  headings: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.object])),
+  paragraphs: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.object])),
   catalog: catalogShape.isRequired
 };
 

--- a/src/specimens/Type.js
+++ b/src/specimens/Type.js
@@ -143,8 +143,8 @@ Type.propTypes = {
   weight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   tracking: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   image: PropTypes.string,
-  headings: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array])),
-  paragraphs: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array])),
+  headings: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.shape])),
+  paragraphs: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.shape])),
   catalog: catalogShape.isRequired
 };
 

--- a/src/specimens/Type.js
+++ b/src/specimens/Type.js
@@ -84,11 +84,13 @@ class Type extends React.Component {
 
     const headings = options.headings
       ? options.headings.map( (heading, i) => {
-        const isPixel = typeof heading === 'number' ? 'px' : '';
+        const headingValue = typeof heading === "object" ? heading.value : heading;
+        const headingLabel = typeof heading === "object" ? heading.label : 'h' + (i + 1);
+        const isPixel = typeof headingValue === 'number' ? 'px' : '';
         return (
           <div key={i}>
-            <div style={{...styles.title, ...fontColor}}>h{i + 1} ({heading + isPixel})</div>
-            <div style={{...styles.heading, ...letterSpacing, font: `${isItalic} normal ${fontWeight} ${heading + isPixel} ${fontFamily}`}}>{headlineText}</div>
+            <div style={{...styles.title, ...fontColor}}>{headingLabel} ({headingValue + isPixel})</div>
+            <div style={{...styles.heading, ...letterSpacing, font: `${isItalic} normal ${fontWeight} ${headingValue + isPixel} ${fontFamily}`}}>{headlineText}</div>
           </div>
         );
       })
@@ -96,13 +98,16 @@ class Type extends React.Component {
 
     const paragraphs = options.paragraphs
       ? options.paragraphs.map( (paragraph, i) => {
-        const values = paragraph.split('/').map((item) => {
+        const paragraphValue = typeof paragraph === "object" ? paragraph.value : paragraph;
+        const paragraphLabel = typeof paragraph === "object" ? paragraph.label : 'Paragraph';
+
+        const values = paragraphValue.split('/').map((item) => {
           return /[a-z]/i.test(item) ? `${item}` : `${item}px`;
         }).join('/');
         return (
           <div key={i}>
             <div style={{...styles.title, ...fontColor}}>
-              Paragraph ({values})
+              {paragraphLabel} ({values})
             </div>
             <div style={{...styles.paragraph, ...letterSpacing, font: `${isItalic} normal ${fontWeight} ${values} ${fontFamily}`}}>
               {truncate ? `${dummyText.substring(0, 200)}…` : dummyText}
@@ -138,8 +143,8 @@ Type.propTypes = {
   weight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   tracking: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   image: PropTypes.string,
-  headings: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
-  paragraphs: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
+  headings: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array])),
+  paragraphs: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array])),
   catalog: catalogShape.isRequired
 };
 

--- a/src/specimens/Type.js
+++ b/src/specimens/Type.js
@@ -84,8 +84,8 @@ class Type extends React.Component {
 
     const headings = options.headings
       ? options.headings.map( (heading, i) => {
-        const headingValue = typeof heading === "object" ? heading.value : heading;
-        const headingLabel = typeof heading === "object" ? heading.label : 'h' + (i + 1);
+        const headingValue = typeof heading === 'object' ? heading.value : heading;
+        const headingLabel = typeof heading === 'object' ? heading.label : 'h' + (i + 1);
         const isPixel = typeof headingValue === 'number' ? 'px' : '';
         return (
           <div key={i}>
@@ -98,8 +98,8 @@ class Type extends React.Component {
 
     const paragraphs = options.paragraphs
       ? options.paragraphs.map( (paragraph, i) => {
-        const paragraphValue = typeof paragraph === "object" ? paragraph.value : paragraph;
-        const paragraphLabel = typeof paragraph === "object" ? paragraph.label : 'Paragraph';
+        const paragraphValue = typeof paragraph === 'object' ? paragraph.value : paragraph;
+        const paragraphLabel = typeof paragraph === 'object' ? paragraph.label : 'Paragraph';
 
         const values = paragraphValue.split('/').map((item) => {
           return /[a-z]/i.test(item) ? `${item}` : `${item}px`;

--- a/src/specimens/Type.js
+++ b/src/specimens/Type.js
@@ -143,8 +143,8 @@ Type.propTypes = {
   weight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   tracking: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   image: PropTypes.string,
-  headings: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.shape({label:PropTypes.string,value:PropTypes.oneOfType([PropTypes.string, PropTypes.number])})])),
-  paragraphs: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.shape({label:PropTypes.string,value:PropTypes.oneOfType([PropTypes.string, PropTypes.number])})])),
+  headings: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.shape({label: PropTypes.string, value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])})])),
+  paragraphs: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.shape({label: PropTypes.string, value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])})])),
   catalog: catalogShape.isRequired
 };
 


### PR DESCRIPTION
I saw this in #296 and didn't realize how much I wanted to customize the Type specimen.

The normal type specimen would allow an array of values to generate the previews like this:
```
``type
{
  "headings": [49, 38, 27, 24, 21, 19 ],
  "paragraphs": ["15/22.5","13/19.5"]
}
``
```

I changed it so that you can also make the array include objects with `label` and `value` keys to customize the label that is shown

```
``type
{
  "headings": [
  	{ "label": "Headline 1", "value": 49},
	{ "label": "Headline 2", "value": 38},
	{ "label": "Headline 3", "value": 27},
	{ "label": "Headline 4", "value": 24},
	{ "label": "Headline 5", "value": 21},
	{ "label": "Headline 6", "value": 19},
  ],
  "paragraphs": [
  	{ "label": "Body Copy", "value": "15/22.5"},
	{ "label": "Small Text", "value": "13/19.5"}
  ]
}
``
```

For my own personal use case, this lets me use CSS classes as labels.