### PR TITLE
Allow to re-order responsive sizes

### DIFF
--- a/src/utils/validateSizes.js
+++ b/src/utils/validateSizes.js
@@ -10,9 +10,9 @@ const validateSizes = (input, catalogSizes) => {
     const foundInList = catalogSizes.find(val => input === val.name);
     return foundInList ? [].concat(foundInList) : false;
   } else if (isArray && input.length === input.filter((item=> typeof item === 'string')).length) {
-    const filtered = catalogSizes.filter( val => {
-      return input.find( d=> d === val.name);
-    });
+    const filtered = input.map(name => (
+      catalogSizes.find(size => size.name === name)
+    )).filter(Boolean);
     return filtered.length === input.length ? filtered : false;
   }
   return false;

--- a/src/utils/validateSizes.test.js
+++ b/src/utils/validateSizes.test.js
@@ -14,6 +14,18 @@ test('Value is Array, consisting of defined sizes', () => {
   expect(DefaultResponsiveSizes).toEqual(validateSizes( values, DefaultResponsiveSizes ));
 });
 
+test('Value is Array, allow re-ordering defined sizes', () => {
+  const sizes = [
+    {name: 'small', width: 360, height: 640},
+    {name: 'xlarge', width: 1920, height: 1080}
+  ];
+  const values = ['xlarge', 'small'];
+  expect(validateSizes( values, DefaultResponsiveSizes )).toEqual([
+    sizes[1],
+    sizes[0]
+  ]);
+});
+
 test('Value is Array, not containing at least one of the defined sizes', () => {
   const values = ['camera obscura', 'That weird giant sony rear projection TV'];
   expect(validateSizes( values, DefaultResponsiveSizes )).toBeFalsy();


### PR DESCRIPTION
Currently when specifying a specific array of sizes for a specimen the order is not respected and overruled with by the global order of responsive sizes.

IMO the local order should win, allowing to showcase a specific size first.