### PR TITLE
Use textColor as the top-level container color

### DIFF
--- a/src/components/App/AppLayout.js
+++ b/src/components/App/AppLayout.js
@@ -30,7 +30,7 @@ const MenuIcon = (props) => (
 
 const getStyles = (theme, sidebarVisible) => ({
   container: {
-    color: theme.pageHeadingTextColor,
+    color: theme.textColor,
     margin: 0,
     padding: 0,
     width: '100%',


### PR DESCRIPTION
This is the more correct global color to set on the document. The PageHeader is also correctly setting its color to pageHeadingTextColor to override the top-level container color.

Currently, the `AppLayout` container's color is inherited by elements in specimens so if the page heading color was white (that is `pageHeadingTextColor: #fff`) then content in specimens would be white instead of whatever `theme.textColor` was.