### PR TITLE
Fix #345 — don’t force theme colour on the entire page but just menuIcon.

### DIFF
--- a/src/components/App/AppLayout.js
+++ b/src/components/App/AppLayout.js
@@ -30,7 +30,6 @@ const MenuIcon = (props) => (
 
 const getStyles = (theme, sidebarVisible) => ({
   container: {
-    color: theme.pageHeadingTextColor,
     margin: 0,
     padding: 0,
     width: '100%',
@@ -45,6 +44,7 @@ const getStyles = (theme, sidebarVisible) => ({
     }
   },
   menuIcon: {
+    color: theme.pageHeadingTextColor,
     cursor: 'pointer',
     height: 30,
     left: 20,


### PR DESCRIPTION
An attempt to fix this: https://github.com/interactivethings/catalog/issues/345