### PR TITLE
Add option to enable/disable babelrc

### DIFF
--- a/cli/src/actions/loadConfigFile.js
+++ b/cli/src/actions/loadConfigFile.js
@@ -3,7 +3,8 @@ import {resolveAppPath} from '../utils/paths';
 import {exists} from 'sander';
 
 type ConfigFile = {
-  webpack?: Function
+  webpack?: Function,
+  useBabelrc?: boolean
 } | null;
 
 export default async (): Promise<ConfigFile> => {

--- a/cli/src/actions/loadWebpackConfig.js
+++ b/cli/src/actions/loadWebpackConfig.js
@@ -16,12 +16,12 @@ type LoadWebpackOptions = {
   paths: Object,
   framework: string,
   dev: boolean,
-  url?: string,
+  useBabelrc: boolean,
+  url?: string
 };
 type WebpackConfig = {};
 
-export default async ({paths, framework, dev, url}: LoadWebpackOptions): WebpackConfig => {
-  const useBabelrc = await exists(paths.babelrc);
+export default async ({paths, framework, dev, url, useBabelrc}: LoadWebpackOptions): WebpackConfig => {
   const frameworkConfig = framework === 'NEXT'
     ? nextConfig(paths, useBabelrc, dev)
     : createReactAppConfig(paths, useBabelrc, dev);

--- a/cli/src/bin/catalog-build.js
+++ b/cli/src/bin/catalog-build.js
@@ -5,12 +5,14 @@ process.env.NODE_ENV = 'production';
 
 import args from 'args';
 import chalk from 'chalk';
+import {exists} from 'sander';
 
-import {infoMessage, errorMessage, successMessage, warningMessage} from '../utils/format';
+import {errorMessage, warningMessage, infoMessageDimmed} from '../utils/format';
 
 import loadWebpackConfig from '../actions/loadWebpackConfig';
 import loadConfigFile from '../actions/loadConfigFile';
 import detectFramework from '../actions/detectFramework';
+import type {Framework} from '../actions/detectFramework';
 import loadPaths from '../actions/loadPaths';
 
 import setupCatalog from '../actions/setupCatalog';
@@ -19,11 +21,26 @@ import runBuild from '../actions/runBuild';
 args
   .option(['o', 'out'], 'Directory to build into', '<catalog directory>/build')
   .option(['u', 'public-url'], 'The URL where production assets get loaded from', '/')
-  .option('public-path', '[DEPRECATED] Use --public-url');
+  .option('public-path', '[DEPRECATED] Use --public-url')
+  .option('babelrc', 'Use local .babelrc file (defaults to true)');
 
-const cliOptions = args.parse(process.argv, {value: '<catalog directory>'});
+const cliOptions = args.parse(process.argv, {value: '<catalog directory>', mri: {
+  boolean: ['babelrc']
+}});
 
-const run = async (catalogSrcDir: string = 'catalog', {out, publicPath, publicUrl}: {out: string, publicPath: ?string, publicUrl: string}) => {
+const getFrameworkName = (framework: Framework): string => {
+  switch (framework) {
+  case 'CREATE_REACT_APP':
+    return 'Create React App';
+  case 'NEXT':
+    return 'next.js (support is experimental)';
+  case 'UNKNOWN':
+  default:
+    return '';
+  }
+};
+
+const run = async (catalogSrcDir: string = 'catalog', {out, publicPath, publicUrl, babelrc}: {out: string, publicPath: ?string, publicUrl: string, babelrc: void | boolean}) => {
   const framework = await detectFramework();
 
   const configFile = await loadConfigFile();
@@ -36,7 +53,13 @@ const run = async (catalogSrcDir: string = 'catalog', {out, publicPath, publicUr
 
   const paths = await loadPaths(catalogSrcDir, out.replace('<catalog directory>', catalogSrcDir), framework, webpackPublicPath);
 
-  const webpackOptions = {paths, dev: false, framework};
+  const babelrcExists: boolean = await exists(paths.babelrc);
+
+  const useBabelrc = babelrc !== undefined ? babelrc :
+    configFile && configFile.useBabelrc !== undefined ? configFile.useBabelrc :
+    babelrcExists;
+
+  const webpackOptions = {paths, dev: false, framework, useBabelrc};
 
   let webpackConfig = await loadWebpackConfig(webpackOptions);
 
@@ -51,6 +74,17 @@ const run = async (catalogSrcDir: string = 'catalog', {out, publicPath, publicUr
   console.log(chalk`
   Building Catalog. This may take a while …
 `);
+
+  if (configFile) {
+    console.log(infoMessageDimmed('  Using configuration file catalog.config.js'));
+  }
+  if (framework !== 'UNKNOWN') {
+    console.log(infoMessageDimmed('  Detected ' + getFrameworkName(framework)));
+  }
+  if (useBabelrc) {
+    console.log(infoMessageDimmed('  Using custom .babelrc'));
+  }
+
   await runBuild(webpackConfig, paths);
   console.log(chalk`  {green Built Catalog into} ${paths.unresolvedCatalogBuildDir}
 `);


### PR DESCRIPTION
Sometimes the automatic behavior of using the existing `.babelrc` file is not desired.

In the future I want to make this **opt-in** but this would be a breaking change.