### PR TITLE
Fixes Installation React guide link

### DIFF
--- a/docs/installation/module.md
+++ b/docs/installation/module.md
@@ -31,4 +31,4 @@ ReactDOM.render(
 );
 ```
 
-See the [React API](/api/react) guide for more details.
+See the [React API](/guides/react) guide for more details.


### PR DESCRIPTION
Hi!

Going through the docs I noticed there's a link pointing to an unexisting path. This fixes it and points to the currently correct path. 