### PR TITLE
Html sketchapp support

### DIFF
--- a/src/specimens/Color.js
+++ b/src/specimens/Color.js
@@ -19,7 +19,7 @@ class Color extends React.Component {
 
     return (
       <div style={{ width: "100%" }}>
-        <div style={{ height: 120, background: value }} />
+        <div style={{ height: 120, background: value }} data-sketch-color={value} />
         <div style={styles.text}>
           {name} <div style={{ fontFamily: theme.fontMono }}>{value}</div>
         </div>

--- a/src/specimens/ColorPalette.js
+++ b/src/specimens/ColorPalette.js
@@ -8,7 +8,7 @@ import { hcl } from "d3-color";
 const _ColorPaletteItem = ({ name, value, styles, width }) => {
   const contrastingValue = hcl(value).l < 55 ? "#fff" : "#000";
   return (
-    <div style={{ width, ...styles.paletteItem, backgroundColor: value }}>
+    <div style={{ width, ...styles.paletteItem, backgroundColor: value }} data-sketch-color={value}>
       <div style={{ ...styles.textPalette, color: contrastingValue }}>
         {name} <div style={styles.mono}>{value}</div>
       </div>

--- a/src/specimens/Type.js
+++ b/src/specimens/Type.js
@@ -164,6 +164,7 @@ class Type extends React.Component {
                   ...letterSpacing,
                   font: `${isItalic} normal ${fontWeight} ${values} ${fontFamily}`
                 }}
+                data-sketch-text={paragraphLabel}
               >
                 {truncate ? `${dummyText.substring(0, 200)}…` : dummyText}
               </div>


### PR DESCRIPTION
This adds initial html-sketchapp-cli support for color, colorpalette and type.  I think adding a `data-sketch-symbol={image title}` if an image has a title could be useful too.