### PR TITLE
Allow babelified/'export default' resources to be fed into `catalog/loader`

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -12,17 +12,21 @@ module.exports.pitch = function pitch(remainingRequest) {
     if (PageRenderer.__esModule) {
       PageRenderer = PageRenderer.default;
     }
+    var resource = require(${resource});
+    if (resource.__esModule) {
+      resource = resource.default;
+    }
     var WrappedPageRenderer = createReactClass({
       displayName: 'WrappedPageRenderer',
       getInitialState: function() {
-        return {content: require(${resource})};
+        return {content: resource};
       },
       componentWillMount: function() {
         var component = this;
         if (module.hot) {
           module.hot.accept(${resource}, function() {
             component.setState({
-              content: require(${resource})
+              content: resource
             })
           })
         }


### PR DESCRIPTION
**Use case:**
During development of a (pre) loader for Catalog (@see discussion in https://github.com/interactivethings/catalog/issues/403), I stumble across some error when trying to feed a "babelified" React Component to the `catalog/loader`.

eg: 
```js
{
    test: /(\.catalog-builder\.yml)/,
    use: ['catalog/loader', 'babel-loader', 'my-custom-loader']
},
```