### PR TITLE
Allow arrays in markdown template literal

### DIFF
--- a/docs/test/testtemplate.js
+++ b/docs/test/testtemplate.js
@@ -1,4 +1,5 @@
-import { markdown } from "catalog";
+import React from "react";
+import { markdown, ReactSpecimen } from "catalog";
 import logo from "../catalog_logo.svg";
 
 export default () => markdown`
@@ -14,4 +15,12 @@ title: Neat!
 Super nice stuff here!
 
 Foo bar
+
+${["foo", "bar"].map(d => [
+  `### ${d}`,
+  <ReactSpecimen key="foo">
+    <div>{d}</div>
+  </ReactSpecimen>
+])}
+
 `;

--- a/src/__snapshots__/markdownPage.test.js.snap
+++ b/src/__snapshots__/markdownPage.test.js.snap
@@ -26,7 +26,13 @@ exports[`Catalog markdown page template literal with arbitrary values 1`] = `
 A paragraph 123
 
 ~~~
-[{"a":"some"},{"a":"data"}]
+
+  foo
+  bar
+  <div>
+    hello
+  </div>
+  
 ~~~
 
 </Page>

--- a/src/markdownPage.js
+++ b/src/markdownPage.js
@@ -35,8 +35,8 @@ const markdownPage = (strings, ...values) =>
     {},
     ...values.reduce(
       (a, v, i) => {
-        // If it's a valid React element, just concat to the end of the array
-        if (isValidElement(v)) {
+        // If it's a valid React element or array, just concat to the end of the array
+        if (isValidElement(v) || Array.isArray(v)) {
           return a.concat(v, strings[i + 1]);
         }
 

--- a/src/markdownPage.test.js
+++ b/src/markdownPage.test.js
@@ -26,7 +26,7 @@ test("Catalog markdown page template literal with arbitrary values", () => {
 A paragraph ${123}
 
 ~~~
-${[{ a: "some" }, { a: "data" }]}
+${["foo", "bar", <div>hello</div>]}
 ~~~
 `;
   expect(page).toMatchSnapshot();


### PR DESCRIPTION
Concatenate arrays to output in markdown template literals instead of JSON-stringifying them. A better version would also handle the content of the array but this is fine as a small improvement.

Partially fixes #403 
