### PR TITLE
add a .prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,2 @@
+semi: true
+quotes: false


### PR DESCRIPTION
Without a .prettierrc file some code editors will fall back to their default. My default happens to differ from the prettier defaults so when working on Catalog prettier tries to cause trouble. This makes sure it does not and keeps things consistent.