### PR TITLE
switch from em to rem

### DIFF
--- a/src/styles/typography.js
+++ b/src/styles/typography.js
@@ -12,7 +12,7 @@ const baseTextStyle = {
 
 // Modular scale font size helper; level can be negative (for smaller font sizes) and positive (for larger font sizes) integers; level 0 === baseFontSize
 export const getFontSize = ({ baseFontSize, msRatio }, level = 0) =>
-  `${baseFontSize / 16 * Math.pow(msRatio, level)}em`;
+  `${baseFontSize / 16 * Math.pow(msRatio, level)}rem`;
 
 // Exports
 


### PR DESCRIPTION
When a table specimen is used with a `baseFontSize` other than tha default `16px` the table cells are displayed with a strange font size. That's because the font size of the `table` gets multiplied with the one of the `cell` or the `paragraph`. For example for `baseFontSize` set to `18px`: `18 / 16 = 1.125em` (which will result in a calculated font size of `22.7833px` (`1.25 * 1.25 * 18`).

Switching to rem (root em) solves this issue.