### PR TITLE
Allow name field to accept multiline specs

### DIFF
--- a/src/specimens/Color.js
+++ b/src/specimens/Color.js
@@ -17,7 +17,8 @@ class Color extends React.Component {
         ...text(theme),
         boxSizing: "border-box",
         padding: "8px 0",
-        background: theme.background
+        background: theme.background,
+        whiteSpace: 'pre-line',
       }
     };
 


### PR DESCRIPTION
ie. to get these lines:
Primary Red
PMS Red 032
C 0 M 86 Y 63 K 0  R 239 G 51 B 64
#EF3340

ie. ```color
span: 3
name: "Primary Red\nPMS Red 032\nC 0 M 86 Y 63 K 0 R 239 G 51 B 64"
value: "#e8324e"
```

Not sure if this is best or making an additional optional prop like 'additionalSpecs' that's an array. 