### PR TITLE
Make color palette in horizontal mode span the full width of the page

### DIFF
--- a/packages/core/src/specimens/ColorPalette.js
+++ b/packages/core/src/specimens/ColorPalette.js
@@ -71,7 +71,7 @@ class ColorPalette extends React.Component {
       }
     };
 
-    const width = `${horizontal ? 90 / colors.length : 100}%`;
+    const width = `${horizontal ? 100 / colors.length : 100}%`;
     const paletteItems = colors.map((color, i) => (
       <ColorPaletteItem key={i} {...color} styles={styles} width={width} />
     ));


### PR DESCRIPTION
I don't see any reason to use 90% instead of 100%. The code was added in bcdb7786.