### PR TITLE
Apply Airship custom reference

### DIFF
--- a/src/components/App/AppLayout.js
+++ b/src/components/App/AppLayout.js
@@ -5,7 +5,7 @@ import { pageShape, pagesShape } from "../../CatalogPropTypes";
 import NavigationBar from "./NavigationBar";
 import PageHeader from "../Page/PageHeader";
 
-const SIDEBAR_WIDTH = 251;
+const SIDEBAR_WIDTH = 221;
 const SIDEBAR_ANIMATION_DURATION = 0.25;
 
 injectGlobal`
@@ -58,28 +58,10 @@ const getStyles = (theme, sidebarVisible) => ({
     width: SIDEBAR_WIDTH - 1,
     top: 0,
     left: 0,
-    borderRight: `1px solid ${theme.sidebarColorLine}`,
-    transform: `translateX(${sidebarVisible ? 0 : -SIDEBAR_WIDTH}px)`,
-    transition: `transform ${SIDEBAR_ANIMATION_DURATION}s ease-in-out`,
-    WebkitOverflowScrolling: "touch",
-    "@media (min-width: 1000px)": {
-      transform: `translateX(0px)`,
-      transition: "none"
-    }
+    borderRight: `1px solid ${theme.sidebarColorLine}`
   },
   navBackground: {
-    position: "fixed",
-    top: 0,
-    left: 0,
-    width: "100vw",
-    height: "100vh",
-    backgroundColor: "rgba(0, 0, 0, 0.2)",
-    opacity: sidebarVisible ? 1 : 0,
-    visibility: sidebarVisible ? "visible" : "hidden",
-    transition: `opacity ${SIDEBAR_ANIMATION_DURATION}s, visibility ${SIDEBAR_ANIMATION_DURATION}s`,
-    "@media (min-width: 1000px)": {
-      display: "none"
-    }
+    display: "none"
   },
   content: {
     background: theme.background,
@@ -90,26 +72,16 @@ const getStyles = (theme, sidebarVisible) => ({
     flexDirection: "column",
     position: "relative",
     zIndex: 0, // To create a new stacking context, see #223.
-    "@media (min-width: 1000px)": {
-      paddingLeft: SIDEBAR_WIDTH
-    }
+    paddingLeft: SIDEBAR_WIDTH
   }
 });
 
 class AppLayout extends React.Component {
   constructor() {
     super();
-    this.toggleSidebar = this.toggleSidebar.bind(this);
     this.state = {
-      sidebarVisible: false
+      sidebarVisible: true
     };
-  }
-
-  toggleSidebar(e) {
-    e.preventDefault();
-    this.setState({
-      sidebarVisible: !this.state.sidebarVisible
-    });
   }
 
   render() {
@@ -140,13 +112,9 @@ class AppLayout extends React.Component {
         </div>
         <MenuIcon
           className={css(styles.menuIcon)}
-          onClick={this.toggleSidebar}
-          onTouchEnd={this.toggleSidebar}
         />
         <div
           className={css(styles.navBackground)}
-          onClick={this.toggleSidebar}
-          onTouchEnd={this.toggleSidebar}
         />
         <div className={css(styles.sideNav)}>{sideNav}</div>
       </div>

--- a/src/components/HighlightedCode/HighlightedCode.js
+++ b/src/components/HighlightedCode/HighlightedCode.js
@@ -10,7 +10,7 @@ const getStyle = theme => {
   return {
     pre: {
       ...text(theme, -0.5),
-      background: "#fff",
+      background: theme.codeStyles.backgroundColor,
       border: "none",
       boxSizing: "border-box",
       color: theme.codeColor,
@@ -35,8 +35,9 @@ const isToken = t => t instanceof Prism.Token;
 const renderPrismTokens = (tokens, styles) => {
   return tokens.map((t, i) => {
     if (isToken(t)) {
+      console.log(t.type);
       return (
-        <span key={`${t.type}-${i}`} className={css(styles[t.type])}>
+        <span key={`${t.type}-${i}`} className={css(styles[t.type])} data-type={`${t.type}`}>
           {Array.isArray(t.content)
             ? renderPrismTokens(t.content, styles)
             : t.content}
@@ -63,9 +64,9 @@ export default class HighlightedCode extends Component {
         <code className={css(styles.code)}>
           {lang
             ? renderPrismTokens(
-                Prism.tokenize(code, Prism.languages[lang], lang),
-                theme.codeStyles
-              )
+              Prism.tokenize(code, Prism.languages[lang], lang),
+              theme.codeStyles
+            )
             : code}
         </code>
       </pre>

--- a/src/components/Menu/ListItem.js
+++ b/src/components/Menu/ListItem.js
@@ -15,36 +15,32 @@ const baseLinkStyle = {
 const style = theme => {
   return {
     link: {
-      ...text(theme),
       ...baseLinkStyle,
-      borderTop: `1px solid ${theme.sidebarColorLine}`,
-      color: theme.sidebarColorText,
+      fontFamily: '"Open sans","Helvetica Neue",Helvetica,Arial,sans-serif;',
+      fontSize: "12px",
+      lineHeight: "16px",
+      fontWeight: "700",
+      borderTop: "none",
+      color: theme.textColor,
       cursor: "pointer",
       display: "block",
-      margin: 0,
-      padding: "16px 40px",
+      margin: "20px 16px",
       textDecoration: "none",
       "&:hover, &:active, &:focus": {
         ...baseLinkStyle,
-        borderTop: `1px solid ${theme.sidebarColorLine}`,
-        color: theme.sidebarColorTextActive,
-        textDecoration: "none",
+        borderTop: "none",
+        textDecoration: "underline",
         background: "rgba(255,255,255,0.1)"
       }
     },
     activeLink: {
-      color: theme.sidebarColorTextActive,
-      cursor: "auto",
-      padding: "16px 40px 8px 40px",
+      cursor: "pointer",
+      margin: "32px 16px",
       "&:hover, &:active, &:focus": {
         ...baseLinkStyle,
-        borderTop: `1px solid ${theme.sidebarColorLine}`,
-        color: theme.sidebarColorTextActive,
-        textDecoration: "none",
+        borderTop: "none",
+        textDecoration: "underline",
         background: "none"
-      },
-      "&:last-child": {
-        padding: "16px 40px"
       }
     },
     listItem: {
@@ -55,21 +51,20 @@ const style = theme => {
     nestedLink: {
       borderTop: "none",
       borderBottom: "none",
-      padding: "8px 24px 8px 60px",
+      margin: "0 16px 12px 28px",
+      fontWeight: 400,
       "&:hover, &:active, &:focus": {
         ...baseLinkStyle,
-        color: theme.sidebarColorTextActive,
-        textDecoration: "none",
+        textDecoration: "underline",
         background: "rgba(255,255,255,0.1)"
       }
     },
     nestedActiveLink: {
-      color: theme.sidebarColorTextActive,
-      cursor: "auto",
+      cursor: "pointer",
+      fontWeight: 700,
       "&:hover, &:active, &:focus": {
         ...baseLinkStyle,
-        color: theme.sidebarColorTextActive,
-        textDecoration: "none",
+        textDecoration: "underline",
         background: "none"
       }
     },
@@ -149,15 +144,15 @@ class ListItem extends React.Component {
         {pages ? (
           <NestedList {...this.props} {...page} pages={pages} />
         ) : (
-          <Link
-            className={linkStyle}
-            activeClassName={activeLinkStyle}
-            to={path}
-            onlyActiveOnIndex={path === "/"}
-          >
-            {menuTitle || title}
-          </Link>
-        )}
+            <Link
+              className={linkStyle}
+              activeClassName={activeLinkStyle}
+              to={path}
+              onlyActiveOnIndex={path === "/"}
+            >
+              {menuTitle || title}
+            </Link>
+          )}
       </li>
     );
   }

--- a/src/styles/typography.js
+++ b/src/styles/typography.js
@@ -32,6 +32,7 @@ export const heading = (theme, level = 0) => ({
   color: theme.brandColor,
   fontFamily: theme.fontHeading,
   fontSize: getFontSize(theme, level),
+  fontWeight: 600,
   lineHeight: theme.msRatio,
   position: "relative"
 });


### PR DESCRIPTION
Fixes https://github.com/CartoDB/airship/issues/543
----

Reference menu now doesn't hide under 1000 px and it looks now almost identical to our other reference sidebars:

![image](https://user-images.githubusercontent.com/1078228/50915826-e76ecb00-1439-11e9-8288-7cf43d8ac42a.png)

Code highlight is closer to our other highlights. It doesn't look equal because the tokenizer is different and has different token types that are shared between JS and HTML.

JS
![image](https://user-images.githubusercontent.com/1078228/50915880-040b0300-143a-11e9-91ff-82f13f467e4f.png)

HTML
![image](https://user-images.githubusercontent.com/1078228/50915906-138a4c00-143a-11e9-8637-877484fdb12f.png)

Headings are equal now.

![image](https://user-images.githubusercontent.com/1078228/50915985-3c124600-143a-11e9-8c1a-3d40c4bc691f.png)

 