### PR TITLE
Update type.md

### DIFF
--- a/docs/specimens/type.md
+++ b/docs/specimens/type.md
@@ -15,6 +15,7 @@
 - `kafka: boolean` Mighty morphin' Samsa fill text
 - `single: boolean` Uses a single word for headline
 - `span: number[1–6]` width of the specimen
+- `shorter: boolean` clips overflow paragraph text with ellipsis
 
 
 ### Examples


### PR DESCRIPTION
first contribution, apologies if off the mark here -- from what I can gather, is `shorter` cutting out excessive lorem ipsum text in the paragraph? if so, what determines the cutoff -- does the specimen have a default height value?